### PR TITLE
perl5400deltaを翻訳する

### DIFF
--- a/docs/perl/5.40.0/perl5400delta.pod
+++ b/docs/perl/5.40.0/perl5400delta.pod
@@ -1,0 +1,3940 @@
+
+=encoding utf8
+
+=head1 NAME
+
+=begin original
+
+perldelta - what is new for perl v5.40.0
+
+=end original
+
+perl5400delta - perl v5.40.0 での変更点
+
+=head1 DESCRIPTION
+
+=begin original
+
+This document describes differences between the 5.38.0 release and the 5.40.0
+release.
+
+=end original
+
+この文書は 5.38.0 リリースと 5.40.0 リリースの変更点を記述しています。
+
+=head1 Core Enhancements
+
+(コアの拡張)
+
+=head2 New C<__CLASS__> Keyword
+
+(新しい C<__CLASS__> キーワード)
+
+=begin original
+
+When using the new C<class> feature, code inside a method, C<ADJUST> block or
+field initializer expression is now permitted to use the new C<__CLASS__>
+keyword.  This yields a class name, similar to C<__PACKAGE__>, but whereas that
+gives the compile-time package that the code appears in, the C<__CLASS__>
+keyword is aware of the actual run-time class that the object instance is a
+member of.  This makes it useful for method dispatch on that class, especially
+during constructors, where access to C<$self> is not permitted.
+
+=end original
+
+新しい C<class> 機能を使う場合、メソッド内のコード、C<ADJUST> ブロックまたは
+フィールド初期化式は、新しい C<__CLASS__> キーワードを使えるようになりました。
+これにより、C<__PACKAGE__> に似たクラス名が生成されますが、コードが
+表示されるコンパイル時パッケージが生成されるのに対して、
+C<__CLASS__> キーワードは、オブジェクトインスタンスがメンバである実際の
+実行時クラスを認識します。
+これにより、特に C<$self> へのアクセスが許可されていないコンストラクタで、
+そのクラスのメソッドディスパッチに便利になります。
+
+=begin original
+
+For more information, see L<perlfunc/__CLASS__>.
+
+=end original
+
+さらなる詳細については、L<perlfunc/__CLASS__> を参照してください。
+
+=head2 C<:reader> attribute for field variables
+
+(フィールド変数のための C<:reader> 属性)
+
+=begin original
+
+When using the C<class> feature, field variables can now take a C<:reader>
+attribute.  This requests that an accessor method be automatically created
+that simply returns the value of the field variable from the given instance.
+
+=end original
+
+C<class> 機能を使うとき、フィールド変数は C<:reader> 属性を
+取ることができるようになりました。
+これは、指定されたインスタンスのフィールド値を返すだけの変数を自動的に
+作成するように要求します。
+
+    field $name :reader;
+
+=begin original
+
+Is equivalent to
+
+=end original
+
+これは次と同等です:
+
+    field $name;
+    method name () { return $name; }
+
+=begin original
+
+An alternative name can also be provided:
+
+=end original
+
+別名も提供できます:
+
+    field $name :reader(get_name);
+
+=begin original
+
+For more detail, see L<perlclass/:reader>.
+
+=end original
+
+さらなる詳細については、L<perlclass/:reader> を参照してください。
+
+=head2 Permit a space in C<-M> command-line option
+
+(C<-M> コマンドラインオプションにスペースを許すように)
+
+=begin original
+
+When processing command-line options, perl now allows a space between the
+C<-M> switch and the name of the module after it.
+
+=end original
+
+コマンド行オプションを処理するとき、perl は C<-M> オプションとその後の
+モジュール名の間にスペースを入れることができるようになりました。
+
+    $ perl -M Data::Dumper=Dumper -E 'say Dumper [1,2,3]'
+
+=begin original
+
+This matches the existing behaviour of the C<-I> option.
+
+=end original
+
+これは、既存の C<-I> オプションの振る舞いと一致します。
+
+=head2 Restrictions to C<use VERSION> declarations
+
+(C<use VERSION> 宣言の制限)
+
+=begin original
+
+In Perl 5.36, a deprecation warning was added when downgrading a
+C<use VERSION> declaration from one above version 5.11, to below. This has
+now been made a fatal error.
+
+=end original
+
+Perl 5.36 では、C<use VERSION> 宣言をバージョン 5.11 より上のものから下のものに
+降格する際に、非推奨警告が追加されました。
+これは今回致命的エラーになりました。
+
+=begin original
+
+Additionally, it is now a fatal error to issue a subsequent C<use VERSION>
+declaration when another is in scope, when either version is 5.39 or above.
+This is to avoid complications surrounding imported lexical functions from
+L<builtin>.  A deprecation warning has also been added for any other
+subsequent C<use VERSION> declaration below version 5.39, to warn that it
+will no longer be permitted in Perl version 5.44.
+
+=end original
+
+さらに、どちらかのバージョンが 5.39 以上で、別のバージョンがスコープ内に
+あるとき、引き続く C<use VERSION> 宣言を発行することは致命的エラーになりました。
+これは、L<builtin> からインポートされたレキシカル関数を取り巻く複雑さを
+避けるためです。
+その他のバージョン 5.39 未満の引き続く C<use VERSION> 宣言に対しても、
+Perl バージョン 5.44 では許されなくなることを
+警告するはいしよてい警告が追加されました。
+
+=head2 New C<builtin::inf> and C<builtin::nan> functions (experimental)
+
+(新しい C<builtin::inf> 関数と C<builtin::nan> 関数 (実験的))
+
+=begin original
+
+Two new functions, C<inf> and C<nan>, have been added to the C<builtin>
+namespace.  These act like constants that yield the floating-point infinity
+and Not-a-Number value respectively.
+
+=end original
+
+二つの新しい関数、C<inf> と C<nan> が C<builtin> 名前空間に追加されました。
+これらは、それぞれ浮動小数点数の無限大と非数値を生成する定数のように動作します。
+
+=head2 New C<^^> logical xor operator
+
+(新しい C<^^> 排他的論理和演算子)
+
+=begin original
+
+Perl has always had three low-precedence logical operators C<and>, C<or> and
+C<xor>, as well as three high-precedence bitwise versions C<&>, C<^> and C<|>.
+Until this release, while the medium-precedence logical operators of C<&&> and
+C<||> were also present, there was no exclusive-or equivalent.  This release
+of Perl adds the final C<^^> operator, completing the set.
+
+=end original
+
+Perl には、優先度の低い三つの論理演算子(C<and>, C<or>, C<xor>)と、優先度の高い
+三つのビット単位のバージョン(C<&>, C<^>, C<|>) が常にありました。
+このリリースまでは、C<&&> と C<||> の中優先度の論理演算子もありましたが、
+排他的論理和の同等物はありませんでした。
+このリリースの Perl では、最後のC<^^>演算子が追加され、集合が完成しました。
+
+    $x ^^ $y and say "One of x or y is true, but not both";
+
+=head2 C<try>/C<catch> feature is no longer experimental
+
+(C<try>/C<catch> 機能はもはや実験的ではありません)
+
+=begin original
+
+Prior to this release, the C<try>/C<catch> feature for handling errors was
+considered experimental. Introduced in Perl version 5.34.0, this is now
+considered a stable language feature and its use no longer prints a warning.
+It still must be enabled with L<the 'try' feature|feature/The 'try' feature>.
+
+=end original
+
+このリリースより前では、エラーを扱うための C<try>/C<catch> 昨日は
+実験的と考えられていました。
+Perl バージョン 5.34.0 で導入されたこれは、安定した言語機能として
+考えられるようになり、使ってももはや警告を表示しなくなりました。
+未だに L<'try' 機能|feature/The 'try' feature> で有効にしなければなりません。
+
+=begin original
+
+See L<perlsyn/Try Catch Exception Handling>.
+
+=end original
+
+L<perlsyn/Try Catch Exception Handling> を参照してください。
+
+=head2 C<for> iterating over multiple values at a time is no longer experimental
+
+(C<for> で一度に複数の値を反復するのはもはや実験的ではありません)
+
+=begin original
+
+Prior to this release, iterating over multiple values at a time with C<for> was
+considered experimental. Introduced in Perl version 5.36.0, this is now
+considered a stable language feature and its use no longer prints a warning.
+See L<perlsyn/Compound Statements>.
+
+=end original
+
+このリリースより前では、C<for> で一度に複数の値を反復するのは実験的と
+考えられていました。
+Perl バージョン 5.36.0 で導入されたこれは、安定した言語機能として
+考えられるようになり、使ってももはや警告を表示しなくなりました。
+L<perlsyn/Compound Statements> を参照してください。
+
+=head2 C<builtin> module is no longer experimental
+
+(C<builtin> モジュールはもはや実験的ではありません)
+
+=begin original
+
+Prior to this release, the L<builtin> module and all of its functions were
+considered experimental. Introduced in Perl version 5.36.0, this module is now
+considered stable its use no longer prints a warning. However, several of its
+functions are still considered experimental.
+
+=end original
+
+このリリースより前では、L<builtin> モジュールとその全ての関数は
+実験的と考えられていました。
+Perl バージョン 5.36.0 で導入されたこれは、安定した言語機能として
+考えられるようになり、使ってももはや警告を表示しなくなりました。
+しかし、この関数のいくつかは、未だに実験的と考えられています。
+
+=head2 The C<:5.40> feature bundle adds C<try>
+
+(C<:5.40> 機能の束は C<try> を追加します)
+
+=begin original
+
+The latest version feature bundle now contains the recently-stablized feature
+C<try>. As this feature bundle is used by the C<-E> commandline switch, these
+are immediately available in C<-E> scripts.
+
+=end original
+
+最新バージョンの機能の束には、最近安定化された機能 C<try> が
+含まれることになりました。
+この機能の束は C<-E> コマンドラインオプションによって使われるため、これらは
+C<-E> スクリプトですぐに使えます。
+
+=head2 C<use v5.40;> imports builtin functions
+
+(C<use v5.40;> は builtin 関数をインポートします)
+
+=begin original
+
+In addition to importing a feature bundle, C<use v5.40;> (or later versions)
+imports the corresponding L<builtin version bundle|builtin/Version Bundles>.
+
+=end original
+
+C<use v5.40;> (または以降のバージョン) は、機能の束をインポートすることに
+加えて、対応する L<buildtin のバージョンの束|builtin/Version Bundles> を
+インポートします。
+
+=head1 Security
+
+(セキュリティ)
+
+=head2 CVE-2023-47038 - Write past buffer end via illegal user-defined Unicode property
+
+(CVE-2023-47038 - 不正なユーザー定義 Unicode 特性によるバッファ末尾を超えた書き込み)
+
+=begin original
+
+This vulnerability was reported directly to the Perl security team by
+Nathan Mills C<the.true.nathan.mills@gmail.com>.
+
+=end original
+
+この脆弱性は、Nathan Mills C<the.true.nathan.mills@gmail.com> によって
+Perl セキュリティチームに直接報告されました。
+
+=begin original
+
+A crafted regular expression when compiled by perl 5.30.0 through
+5.38.0 can cause a one-byte attacker controlled buffer overflow in a
+heap allocated buffer.
+
+=end original
+
+巧妙に細工された正規表現を perl 5.30.0 から 5.38.0 でコンパイルすると、
+ヒープに割り当てられたバッファで、攻撃者が制御する 1 バイトの
+バッファオーバーフローが発生する可能性があります。
+
+=head2 CVE-2023-47039 - Perl for Windows binary hijacking vulnerability
+
+(CVE-2023-47039 - Perl での Windows バイナリハイジャック脆弱性)
+
+=begin original
+
+This vulnerability was reported to the Intel Product Security Incident
+Response Team (PSIRT) by GitHub user ycdxsb
+L<https://github.com/ycdxsb/WindowsPrivilegeEscalation>. PSIRT then
+reported it to the Perl security team.
+
+=end original
+
+この脆弱性は、
+Intel Product Security Incident Response Team (PSIRT) が、GitHub ユーザーの
+ycdxsb L<https://GitHub.com/ycdxsb/WindowsPrivilegeEscalation> から報告を受け、
+PSIRT から Perl セキュリティチームに報告されました。
+
+=begin original
+
+Perl for Windows relies on the system path environment variable to
+find the shell (C<cmd.exe>). When running an executable which uses
+Windows Perl interpreter, Perl attempts to find and execute C<cmd.exe>
+within the operating system. However, due to path search order issues,
+Perl initially looks for cmd.exe in the current working directory.
+
+=end original
+
+Windows 用の Perl は、シェル(C<cmd.exe>)を見つけるためにシステムパス環境変数に
+依存します。
+Windows の Perl インタプリタを使う実行可能ファイルを実行する場合、Perl は
+オペレーティングシステム内の C<cmd.exe> を見つけて実行しようとします。
+しかし、パス検索順序の問題により、Perl は最初に現在の作業ディレクトリ内で
+cmd.exe を探します。
+
+=begin original
+
+An attacker with limited privileges can exploit this behavior by
+placing C<cmd.exe> in locations with weak permissions, such as
+C<C:\ProgramData>. By doing so, when an administrator attempts to use
+this executable from these compromised locations, arbitrary code can
+be executed.
+
+=end original
+
+権限が制限された攻撃者は、C<cmd.exe> を C<C:\ProgramData> などの弱い権限を
+持つ場所に配置することで、この動作を不正利用できる可能性があります。
+これにより、管理者がこれらの侵害された場所からこの実行可能ファイルを
+使用しようとしたときに、任意のコードが実行される可能性があります。
+
+=head1 Incompatible Changes
+
+(互換性のない変更)
+
+=head2 reset EXPR now calls set-magic on scalars
+
+(reset EXPR はスカラに対して set-magic を呼び出すようになりました)
+
+=begin original
+
+Previously C<reset EXPR> did not call set magic when clearing scalar variables.
+This meant that changes did not propagate to the underlying internal state
+where needed, such as for C<$^W>, and did not result in an exception where the
+underlying magic would normally throw an exception, such as for C<$1>.
+
+=end original
+
+以前の C<reset EXPR> では、スカラ変数をクリアするときに set magic を
+呼び出しませんでした。
+これは、変更が C<$^W> などの必要な場所で基礎となる内部状態に伝播されず、
+C<$1> などの基礎となるマジックが通常例外を投げるような例外が発生しないことを
+意味していました。
+
+=begin original
+
+This means code that had no effect before may now actually have an effect,
+including possibly throwing an exception.
+
+=end original
+
+つまり、以前は何の効果もなかったコードが、実際には効果を持つようになり、
+例外を投げる可能性もあります。
+
+=begin original
+
+C<reset EXPR> already called set magic when modifying arrays and hashes.
+
+=end original
+
+C<reset EXPR> はすでに、配列とハッシュを変更するときに set magic を
+呼び出しています。
+
+=begin original
+
+This has no effect on plain C<reset> used to reset one-match searches as with
+C<m?pattern?>.
+
+=end original
+
+これは、C<m?pattern?> と同様に、一回のマッチング検索をリセットするために使われる
+単純な C<reset> には影響しません。
+
+[L<GH #20763|https://github.com/Perl/perl5/issues/20763>]
+
+=head2 Calling the import method of an unknown package produces a warning
+
+(不明なパッケージの import メソッドを呼び出すと警告が発生します)
+
+=begin original
+
+Historically, it has been possible to call the C<import> or C<unimport> method of
+any class, including ones which have not been defined, with an argument and not
+experience an error.  For instance, this code will not throw an error in Perl
+5.38:
+
+=end original
+
+歴史的には、定義されていないクラスも含めて、任意のクラスの C<import> または
+C<unimport> メソッドを引数付きで呼び出すことができ、エラーは
+発生しませんでした。
+たとえば、次のコードは Perl 5.38 ではエラーを投げません。
+
+    Class::That::Does::Not::Exist->import("foo");
+
+=begin original
+
+However, as of Perl 5.39.1 this is deprecated and will issue a warning. Note
+that calling these methods with no arguments continues to silently succeed and
+do nothing. For instance,
+
+=end original
+
+しかし、Perl 5.39.1 からこれは廃止予定になり、警告が起こります。
+引数なしでこれらのメソッドを呼び出しても、暗黙に成功し、
+何もしないままであることに注意してください。
+例えば:
+
+    Class::That::Does::Not::Exist->import();
+
+=begin original
+
+will continue to not throw an error.  This is because every class
+implicitly inherits from the class L<UNIVERSAL> which now defines an
+C<import> method.  In older perls there was no such method defined,
+and instead the method calls for C<import> and C<unimport> were special
+cased to not throw errors if there was no such method defined.
+
+=end original
+
+これはエラーを投げません。
+これは、全てのクラスが暗黙にクラス L<UNIVERSAL> から継承しており、クラス
+L<UNIVERSAL> が C<import> メソッドを定義しているためです。
+以前の perl ではそのようなメソッドは定義されておらず、代わりに C<import> と
+C<unimport> のメソッド呼び出しは、そのようなメソッドが定義されていない場合に
+エラーを投げないように特別扱いされていました。
+
+=begin original
+
+This change has been added because it makes it easier to detect case typos in
+C<use> statements when running on case-insensitive file systems.  For instance,
+on Windows or other platforms with case-insensitive file systems on older perls
+the following code
+
+=end original
+
+この変更が追加されたのは、大文字小文字を区別しないファイルシステムで
+実行するときに、C<use> 文の大文字小文字のタイプミスをより簡単に
+検出できるようにするためです。
+例えば、大文字小文字を区別しないファイルシステムを使う Windows または
+その他のプラットフォームで 古い perl を使うと、次のコードは:
+
+    use STRICT 'refs';
+
+=begin original
+
+would silently do nothing as the module is actually called F<strict.pm>, not
+F<STRICT.pm>, so it would be loaded but its import method would never be called.
+It will also detect cases where a user passes an argument when using a package
+that does not provide its own import, for instance most "pure" class
+definitions do not define an import method.
+
+=end original
+
+モジュールは実際には F<STRICT.pm> ではなく F<strict.pm> を呼び出されるため、
+モジュールはロードされますが、そのインポートメソッドは呼び出されないので、
+何もしません。
+また、独自のインポートを提供しないパッケージを使っているときに、
+ユーザが引数を渡す場合も検出されます;
+たとえば、ほとんどの「純粋な」クラス定義ではインポートメソッドが
+定義されていません。
+
+=head2 C<return> no longer allows an indirect object
+
+(C<return> はもはや間接オブジェクトを受け付けません)
+
+=begin original
+
+The C<return> operator syntax now rejects indirect objects.  In most
+cases this would compile and even run, but wasn't documented and could
+produce confusing results, for example:
+
+=end original
+
+C<return> 演算子の構文で、間接オブジェクトが拒否されるようになりました。
+ほとんどの場合、これはコンパイルされて実行されますが、文書化されておらず、
+例えば次のような混乱した結果になる可能性があります:
+
+  # note that sum hasn't been defined
+  sub sum_positive {
+    return sum grep $_ > 0, @_;
+    # unexpectedly parsed as:
+    #   return *sum, grep $_ > 0, @_;
+    # ... with the bareword acting like an extra (typeglob) argument
+  }
+  say for sum_positive(-1, 2, 3)
+
+=begin original
+
+produced:
+
+=end original
+
+これは次を生成します:
+
+  *main::sum
+  2
+  3
+
+[L<GH #21716|https://github.com/Perl/perl5/issues/21716>]
+
+=head2 Class barewords no longer resolved as file handles in method calls under C<no feature "bareword_filehandles">
+
+(C<no feature "bareword_filehandles"> の下でのメソッド呼び出しでは、クラスの裸の単語はもはやファイルハンドルとして解決されなくなりました)
+
+=begin original
+
+Under C<no feature "bareword_filehandles"> bareword file handles
+continued to be resolved in method calls:
+
+=end original
+
+C<no feature "bareword_filehandles"> の下で、裸の単語のファイルハンドルは
+メソッド呼び出しでは引き続き解決されていました:
+
+    open FH, "<", $somefile or die;
+    no feature 'bareword_filehandles';
+    FH->binmode;
+
+=begin original
+
+This has been fixed, so the:
+
+=end original
+
+この問題は修正されたので:
+
+    FH->binmode;
+
+=begin original
+
+will attempt to resolve C<FH> as a class, typically resulting in a
+runtime error.
+
+=end original
+
+これは C<FH> をクラスとして解決しようとし、典型的には
+実行時エラーとなります。
+
+=begin original
+
+The standard file handles such as C<STDOUT> continue to be resolved as
+a handle:
+
+=end original
+
+C<STDOUT>などの標準のファイルハンドルは、引き続きハンドルとして解決されます。
+
+    no feature 'bareword_filehandles';
+    STDOUT->flush; # continues to work
+
+=begin original
+
+Note that once perl resolves a bareword name as a class it will
+continue to do so:
+
+=end original
+
+一旦 perl がある裸の単語をクラスとして解決すると、それは継続して
+行われることに注意してください:
+
+    package SomeClass {
+        sub somemethod{}
+    }
+    open SomeClass, "<", "somefile" or die;
+    # SomeClass resolved as a handle
+    SomeClass->binmode;
+    {
+        no feature "bareword_filehandles";
+        SomeClass->somemethod;
+    }
+    # SomeClass resolved as a class
+    SomeClass->binmode;
+
+[L<GH #19426|https://github.com/Perl/perl5/issues/19426>]
+
+=head1 Deprecations
+
+(廃止予定)
+
+=over 4
+
+=item *
+
+=begin original
+
+Using C<goto> to jump from an outer scope into an inner scope is deprecated
+and will be removed completely in Perl 5.42.  [L<GH #21601|https://github.com/Perl/perl5/issues/21601>]
+
+=end original
+
+C<goto> を使って外部スコープから内部スコープにジャンプすることは
+廃止予定で、Perl 5.42 では完全に削除される予定です。
+[L<GH #21601|https://github.com/Perl/perl5/issues/21601>]
+
+=back
+
+=head1 Performance Enhancements
+
+(性能改善)
+
+=over 4
+
+=item *
+
+=begin original
+
+The negation OPs have been modified to support the generic C<TARGMY> optimization.
+[L<GH #21442|https://github.com/Perl/perl5/issues/21442>]
+
+=end original
+
+否定 OP は、一般的な C<TARGMY> 最適化に対応するように修正されました。
+[L<GH #21442|https://github.com/Perl/perl5/issues/21442>]
+
+=back
+
+=head1 Modules and Pragmata
+
+(モジュールとプラグマ)
+
+=head2 New Modules and Pragmata
+
+(新しいモジュールとプラグマ)
+
+=over 4
+
+=item *
+
+=begin original
+
+L<Term::Table> 0.018 has been added to the Perl core.
+
+=end original
+
+L<Term::Table> 0.018 が Perl コアに追加されました。
+
+=begin original
+
+This module is a dependency of L<Test2::Suite>.
+
+=end original
+
+このモジュールは、L<Test2::Suite> の依存関係です。
+
+=item *
+
+=begin original
+
+L<Test2::Suite> 0.000162 has been added to the Perl core.
+
+=end original
+
+L<Test2::Suite> 0.000162 が Perl コアに追加されました。
+
+=begin original
+
+This distribution contains a comprehensive set of test tools for writing unit
+tests.  It is the successor to L<Test::More> and similar modules.  Its
+inclusion in the Perl core means that CPAN module tests can be written using
+this suite of tools without extra dependencies.
+
+=end original
+
+この配布には、単体テストを作るための包括的なテストツールの集合が
+含まれています。
+これは、L<Test::More> および同様のモジュールの後継です。
+Perl コアに含まれているため、CPAN モジュールテストは、追加の依存関係なしに
+このツールスイートを使って作成できます。
+
+=back
+
+=head2 Updated Modules and Pragmata
+
+(更新されたモジュールとプラグマ)
+
+=over 4
+
+=item *
+
+=begin original
+
+L<Archive::Tar> has been upgraded from version 2.40 to 3.02_001.
+
+=end original
+
+L<Archive::Tar> はバージョン 2.40 から 3.02_001 に更新されました。
+
+=item *
+
+=begin original
+
+L<attributes> has been upgraded from version 0.35 to 0.36.
+
+=end original
+
+L<attributes> はバージョン 0.35 から 0.36 に更新されました。
+
+=item *
+
+=begin original
+
+L<autodie> has been upgraded from version 2.36 to 2.37.
+
+=end original
+
+L<autodie> はバージョン 2.36 から 2.37 に更新されました。
+
+=item *
+
+=begin original
+
+L<B> has been upgraded from version 1.88 to 1.89.
+
+=end original
+
+L<B> はバージョン 1.88 から 1.89 に更新されました。
+
+=item *
+
+=begin original
+
+L<B::Deparse> has been upgraded from version 1.74 to 1.76.
+
+=end original
+
+L<B::Deparse> はバージョン 1.74 から 1.76 に更新されました。
+
+=item *
+
+=begin original
+
+L<Benchmark> has been upgraded from version 1.24 to 1.25.
+
+=end original
+
+L<Benchmark> はバージョン 1.24 から 1.25 に更新されました。
+
+=item *
+
+=begin original
+
+L<bignum> has been upgraded from version 0.66 to 0.67.
+
+=end original
+
+L<bignum> はバージョン 0.66 から 0.67 に更新されました。
+
+=item *
+
+=begin original
+
+L<builtin> has been upgraded from version 0.008 to 0.014.
+
+=end original
+
+L<builtin> はバージョン 0.008 から 0.014 に更新されました。
+
+=begin original
+
+L<builtin> now accepts a version bundle as an input argument, requesting it to
+import all of the functions that are considered a stable part of the module at
+the given Perl version. For example:
+
+=end original
+
+L<builtin> は、入力引数としてバージョンバンドルを受け入れ、指定された
+Perl バージョンでモジュールの安定した部分と見なされる全ての関数を
+インポートするよう要求します。
+例えば:
+
+    use builtin ':5.40';
+
+=begin original
+
+Added the C<load_module()> builtin function as per L<PPC 0006|https://github.com/Perl/PPCs/blob/main/ppcs/ppc0006-load-module.md>.
+
+=end original
+
+L<PPC 0006|https://github.com/Perl/PPCs/blob/main/ppcs/ppc0006-load-module.md> に
+従って、C<load_module()> 組み込み関数が追加されました。
+
+=item *
+
+=begin original
+
+L<bytes> has been upgraded from version 1.08 to 1.09.
+
+=end original
+
+L<bytes> はバージョン 1.08 から 1.09 に更新されました。
+
+=item *
+
+=begin original
+
+L<Compress::Raw::Bzip2> has been upgraded from version 2.204_001 to 2.212.
+
+=end original
+
+L<Compress::Raw::Bzip2> はバージョン 2.204_001 から 2.212 に更新されました。
+
+=item *
+
+=begin original
+
+L<Compress::Raw::Zlib> has been upgraded from version 2.204_001 to 2.212.
+
+=end original
+
+L<Compress::Raw::Zlib> はバージョン 2.204_001 から 2.212 に更新されました。
+
+=item *
+
+=begin original
+
+L<CPAN::Meta::Requirements> has been upgraded from version 2.140 to 2.143.
+
+=end original
+
+L<CPAN::Meta::Requirements> はバージョン 2.140 から 2.143 に更新されました。
+
+=item *
+
+=begin original
+
+L<Data::Dumper> has been upgraded from version 2.188 to 2.189.
+
+=end original
+
+L<Data::Dumper> はバージョン 2.188 から 2.189 に更新されました。
+
+=item *
+
+=begin original
+
+L<DB_File> has been upgraded from version 1.858 to 1.859.
+
+=end original
+
+L<DB_File> はバージョン 1.858 から 1.859 に更新されました。
+
+=item *
+
+=begin original
+
+L<Devel::Peek> has been upgraded from version 1.33 to 1.34.
+
+=end original
+
+L<Devel::Peek> はバージョン 1.33 から 1.34 に更新されました。
+
+=item *
+
+=begin original
+
+L<Devel::PPPort> has been upgraded from version 3.71 to 3.72.
+
+=end original
+
+L<Devel::PPPort> はバージョン 3.71 から 3.72 に更新されました。
+
+=item *
+
+=begin original
+
+L<diagnostics> has been upgraded from version 1.39 to 1.40.
+
+=end original
+
+L<diagnostics> はバージョン 1.39 から 1.40 に更新されました。
+
+=item *
+
+=begin original
+
+L<DynaLoader> has been upgraded from version 1.54 to 1.56.
+
+=end original
+
+L<DynaLoader> はバージョン 1.54 から 1.56 に更新されました。
+
+=item *
+
+=begin original
+
+L<Encode> has been upgraded from version 3.19 to 3.21.
+
+=end original
+
+L<Encode> はバージョン 3.19 から 3.21 に更新されました。
+
+=item *
+
+=begin original
+
+L<Errno> has been upgraded from version 1.37 to 1.38.
+
+=end original
+
+L<Errno> はバージョン 1.37 から 1.38 に更新されました。
+
+=begin original
+
+The C<osvers> and C<archname> baked into the module to ensure Errno is loaded
+by the perl that built it are now more comprehensively escaped.
+[L<GH #21135|https://github.com/Perl/perl5/issues/21135>]
+
+=end original
+
+モジュールを構築した perl によって Errno が確実にロードされるように
+モジュールに組み込まれた C<osvers> と C<archname> が、より包括的に
+エスケープされるようになりました。
+[L<GH #21135|https://github.com/Perl/perl5/issues/21135>]
+
+=item *
+
+=begin original
+
+L<experimental> has been upgraded from version 0.031 to 0.032.
+
+=end original
+
+L<experimental> はバージョン 0.031 から 0.032 に更新されました。
+
+=item *
+
+=begin original
+
+L<Exporter> has been upgraded from version 5.77 to 5.78.
+
+=end original
+
+L<Exporter> はバージョン 5.77 から 5.78 に更新されました。
+
+=item *
+
+=begin original
+
+L<ExtUtils::CBuilder> has been upgraded from version 0.280238 to 0.280240.
+
+=end original
+
+L<ExtUtils::CBuilder> はバージョン 0.280238 から 0.280240 に更新されました。
+
+=item *
+
+=begin original
+
+L<ExtUtils::Manifest> has been upgraded from version 1.73 to 1.75.
+
+=end original
+
+L<ExtUtils::Manifest> はバージョン 1.73 から 1.75 に更新されました。
+
+=item *
+
+=begin original
+
+L<ExtUtils::Miniperl> has been upgraded from version 1.13 to 1.14.
+
+=end original
+
+L<ExtUtils::Miniperl> はバージョン 1.13 から 1.14 に更新されました。
+
+=item *
+
+=begin original
+
+L<Fcntl> has been upgraded from version 1.15 to 1.18.
+
+=end original
+
+L<Fcntl> はバージョン 1.15 から 1.18 に更新されました。
+
+=begin original
+
+The old module documentation stub has been greatly expanded and revised.
+
+=end original
+
+古いモジュール文書のスタブが大幅に拡張され、改訂されました。
+
+=begin original
+
+Adds support for the C<O_TMPFILE> flag on Linux.
+
+=end original
+
+Linux での C<O_TMPFILE> フラグの対応が追加されました。
+
+=item *
+
+=begin original
+
+L<feature> has been upgraded from version 1.82 to 1.89.
+
+=end original
+
+L<feature> はバージョン 1.82 から 1.89 に更新されました。
+
+=begin original
+
+It now documents the C<:all> feature bundle, and suggests a reason why you may
+not wish to use it.
+
+=end original
+
+C<:all> 機能の束について文書化し、この束を使いたくないかもしれない
+理由を示します。
+
+=item *
+
+=begin original
+
+L<fields> has been upgraded from version 2.24 to 2.25.
+
+=end original
+
+L<fields> はバージョン 2.24 から 2.25 に更新されました。
+
+=item *
+
+=begin original
+
+L<File::Compare> has been upgraded from version 1.1007 to 1.1008.
+
+=end original
+
+L<File::Compare> はバージョン 1.1007 から 1.1008 に更新されました。
+
+=item *
+
+=begin original
+
+L<File::Find> has been upgraded from version 1.43 to 1.44.
+
+=end original
+
+L<File::Find> はバージョン 1.43 から 1.44 に更新されました。
+
+=item *
+
+=begin original
+
+L<File::Glob> has been upgraded from version 1.40 to 1.42.
+
+=end original
+
+L<File::Glob> はバージョン 1.40 から 1.42 に更新されました。
+
+=item *
+
+=begin original
+
+L<File::Spec> has been upgraded from version 3.89 to 3.90.
+
+=end original
+
+L<File::Spec> はバージョン 3.89 から 3.90 に更新されました。
+
+=item *
+
+=begin original
+
+L<File::stat> has been upgraded from version 1.13 to 1.14.
+
+=end original
+
+L<File::stat> はバージョン 1.13 から 1.14 に更新されました。
+
+=item *
+
+=begin original
+
+L<FindBin> has been upgraded from version 1.53 to 1.54.
+
+=end original
+
+L<FindBin> はバージョン 1.53 から 1.54 に更新されました。
+
+=item *
+
+=begin original
+
+L<Getopt::Long> has been upgraded from version 2.54 to 2.57.
+
+=end original
+
+L<Getopt::Long> はバージョン 2.54 から 2.57 に更新されました。
+
+=item *
+
+=begin original
+
+L<Getopt::Std> has been upgraded from version 1.13 to 1.14.
+
+=end original
+
+L<Getopt::Std> はバージョン 1.13 から 1.14 に更新されました。
+
+=begin original
+
+Documentation and test improvements only; no change in functionality.
+
+=end original
+
+文書とテストの改善のみ; 機能の変更はありません。
+
+=item *
+
+=begin original
+
+L<Hash::Util> has been upgraded from version 0.30 to 0.32.
+
+=end original
+
+L<Hash::Util> はバージョン 0.30 から 0.32 に更新されました。
+
+=item *
+
+=begin original
+
+L<Hash::Util::FieldHash> has been upgraded from version 1.26 to 1.27.
+
+=end original
+
+L<Hash::Util::FieldHash> はバージョン 1.26 から 1.27 に更新されました。
+
+=item *
+
+=begin original
+
+L<HTTP::Tiny> has been upgraded from version 0.086 to 0.088.
+
+=end original
+
+L<HTTP::Tiny> はバージョン 0.086 から 0.088 に更新されました。
+
+=item *
+
+=begin original
+
+L<I18N::Langinfo> has been upgraded from version 0.22 to 0.24.
+
+=end original
+
+L<I18N::Langinfo> はバージョン 0.22 から 0.24 に更新されました。
+
+=begin original
+
+It now handles the additional locale categories that Linux defines
+beyond those in the POSIX Standard.
+
+=end original
+
+POSIX 標準で定義されている以外に、Linux が定義する追加の
+ロケールカテゴリを扱うようになりました。
+
+=begin original
+
+This fixes what is returned for the C<ALT_DIGITS> item, which has never
+before worked properly in Perl.
+
+=end original
+
+これにより、C<ALT_DIGITS> 項目に返される内容が修正されます;
+これは、これまで Perl では正しく動作していませんでした。
+
+=item *
+
+=begin original
+
+L<IO> has been upgraded from version 1.52 to 1.55.
+
+=end original
+
+L<IO> はバージョン 1.52 から 1.55 に更新されました。
+
+=begin original
+
+Fixed C<IO::Handle/blocking> on Windows, which has been non-functional
+since IO 1.32.  [L<GH #17455|https://github.com/Perl/perl5/issues/17455>]
+
+=end original
+
+IO 1.32 以降機能しなくなっていた Windows の
+C<IO::Handle/blocking> が修正されました。
+[L<GH #17455|https://github.com/Perl/perl5/issues/17455>]
+
+=item *
+
+=begin original
+
+IO-Compress has been upgraded from version 2.204 to 2.212.
+
+=end original
+
+IO-Compress はバージョン 2.204 から 2.212 に更新されました。
+
+=item *
+
+=begin original
+
+L<IO::Socket::IP> has been upgraded from version 0.41_01 to 0.42.
+
+=end original
+
+L<IO::Socket::IP> はバージョン 0.41_01 から 0.42 に更新されました。
+
+=item *
+
+=begin original
+
+L<IO::Zlib> has been upgraded from version 1.14 to 1.15.
+
+=end original
+
+L<IO::Zlib> はバージョン 1.14 から 1.15 に更新されました。
+
+=item *
+
+=begin original
+
+L<locale> has been upgraded from version 1.10 to 1.12.
+
+=end original
+
+L<locale> はバージョン 1.10 から 1.12 に更新されました。
+
+=item *
+
+=begin original
+
+L<Math::BigInt> has been upgraded from version 1.999837 to 2.003002.
+
+=end original
+
+L<Math::BigInt> はバージョン 1.999837 から 2.003002 に更新されました。
+
+=item *
+
+=begin original
+
+L<Math::BigInt::FastCalc> has been upgraded from version 0.5013 to 0.5018.
+
+=end original
+
+L<Math::BigInt::FastCalc> はバージョン 0.5013 から 0.5018 に更新されました。
+
+=item *
+
+=begin original
+
+L<Module::CoreList> has been upgraded from version 5.20230520 to 5.20240609.
+
+=end original
+
+L<Module::CoreList> はバージョン 5.20230520 から 5.20240609 に更新されました。
+
+=item *
+
+=begin original
+
+L<Module::Metadata> has been upgraded from version 1.000037 to 1.000038.
+
+=end original
+
+L<Module::Metadata> はバージョン 1.000037 から 1.000038 に更新されました。
+
+=item *
+
+=begin original
+
+L<mro> has been upgraded from version 1.28 to 1.29.
+
+=end original
+
+L<mro> はバージョン 1.28 から 1.29 に更新されました。
+
+=item *
+
+=begin original
+
+L<NDBM_File> has been upgraded from version 1.16 to 1.17.
+
+=end original
+
+L<NDBM_File> はバージョン 1.16 から 1.17 に更新されました。
+
+=item *
+
+=begin original
+
+L<Opcode> has been upgraded from version 1.64 to 1.65.
+
+=end original
+
+L<Opcode> はバージョン 1.64 から 1.65 に更新されました。
+
+=item *
+
+=begin original
+
+L<perl5db.pl> has been upgraded from version 1.77 to 1.78.
+
+=end original
+
+L<perl5db.pl> はバージョン 1.77 から 1.78 に更新されました。
+
+=begin original
+
+Made parsing of the C<l> command arguments saner.
+[L<GH #21350|https://github.com/Perl/perl5/issues/21350>]
+
+=end original
+
+C<l> コマンド引数のパースをよりまともにしました。
+[L<GH #21350|https://github.com/Perl/perl5/issues/21350>]
+
+=item *
+
+=begin original
+
+L<perlfaq> has been upgraded from version 5.20210520 to 5.20240218.
+
+=end original
+
+L<perlfaq> はバージョン 5.20210520 から 5.20240218 に更新されました。
+
+=item *
+
+=begin original
+
+L<PerlIO::encoding> has been upgraded from version 0.30 to 0.31.
+
+=end original
+
+L<PerlIO::encoding> はバージョン 0.30 から 0.31 に更新されました。
+
+=item *
+
+=begin original
+
+L<PerlIO::scalar> has been upgraded from version 0.31 to 0.32.
+
+=end original
+
+L<PerlIO::scalar> はバージョン 0.31 から 0.32 に更新されました。
+
+=item *
+
+=begin original
+
+L<PerlIO::via> has been upgraded from version 0.18 to 0.19.
+
+=end original
+
+L<PerlIO::via> はバージョン 0.18 から 0.19 に更新されました。
+
+=item *
+
+=begin original
+
+L<Pod::Checker> has been upgraded from version 1.75 to 1.77.
+
+=end original
+
+L<Pod::Checker> はバージョン 1.75 から 1.77 に更新されました。
+
+=item *
+
+=begin original
+
+L<Pod::Html> has been upgraded from version 1.34 to 1.35.
+
+=end original
+
+L<Pod::Html> はバージョン 1.34 から 1.35 に更新されました。
+
+=item *
+
+=begin original
+
+L<Pod::Simple> has been upgraded from version 3.43 to 3.45.
+
+=end original
+
+L<Pod::Simple> はバージョン 3.43 から 3.45 に更新されました。
+
+=item *
+
+=begin original
+
+L<podlators> has been upgraded from version 5.01 to 5.01_02.
+
+=end original
+
+L<podlators> はバージョン 5.01 から 5.01_02 に更新されました。
+
+=item *
+
+=begin original
+
+L<POSIX> has been upgraded from version 2.13 to 2.20.
+
+=end original
+
+L<POSIX> はバージョン 2.13 から 2.20 に更新されました。
+
+=begin original
+
+The C<mktime> function now works correctly on 32-bit platforms even if the
+platform's C<time_t> type is larger than 32 bits. [L<GH #21551|https://github.com/Perl/perl5/issues/21551>]
+
+=end original
+
+C<mktime> 関数は、プラットフォームの C<time_t> 型が 32 ビットより
+大きい場合でも、32 ビットプラットフォームで正しく動作するようになりました。
+[L<GH #21551|https://github.com/Perl/perl5/issues/21551>]
+
+=begin original
+
+The C<T_SIGNO> and C<T_FD> typemap entries have been fixed so they work with
+any variable name, rather than just the hardcoded C<sig> and C<fd>.
+
+=end original
+
+C<T_SIGNO> と C<T_FD> の typemap エントリが修正され、ハードコードされた
+C<sig> と C<fd> だけでなく、任意の変数名で動作するようになりました。
+
+=begin original
+
+The mappings for C<Mode_t>, C<pid_t>, C<Uid_t>, C<Gid_t> and C<Time_t> have
+been updated to be integer types; previously they were C<NV> floating-point.
+
+=end original
+
+C<Mode_t>, C<pid_t>,  C<Uid_t>, C<Gid_t>,  C<Time_t> のマッピングは、
+整数型に更新されました; 以前は C<NV> 浮動小数点型でした。
+
+=begin original
+
+Adjusted the signbit() on NaN test to handle the unusual bit pattern
+returned for NaN by Oracle Developer Studio's compiler.  [L<GH #21533|https://github.com/Perl/perl5/issues/21533>]
+
+=end original
+
+Oracle Developer Studio のコンパイラによって NaN に対して返される異常な
+ビットパターンを扱うために、NaN テストの signbit() が調整されました。
+[L<GH #21533|https://github.com/Perl/perl5/issues/21533>]
+
+=item *
+
+=begin original
+
+L<re> has been upgraded from version 0.44 to 0.47.
+
+=end original
+
+L<re> はバージョン 0.44 から 0.47 に更新されました。
+
+=item *
+
+=begin original
+
+L<Safe> has been upgraded from version 2.44 to 2.46.
+
+=end original
+
+L<Safe> はバージョン 2.44 から 2.46 に更新されました。
+
+=item *
+
+=begin original
+
+L<SelfLoader> has been upgraded from version 1.26 to 1.27.
+
+=end original
+
+L<SelfLoader> はバージョン 1.26 から 1.27 に更新されました。
+
+=item *
+
+=begin original
+
+L<Socket> has been upgraded from version 2.036 to 2.038.
+
+=end original
+
+L<Socket> はバージョン 2.036 から 2.038 に更新されました。
+
+=item *
+
+=begin original
+
+L<strict> has been upgraded from version 1.12 to 1.13.
+
+=end original
+
+L<strict> はバージョン 1.12 から 1.13 に更新されました。
+
+=item *
+
+=begin original
+
+L<Test::Harness> has been upgraded from version 3.44 to 3.48.
+
+=end original
+
+L<Test::Harness> はバージョン 3.44 から 3.48 に更新されました。
+
+=item *
+
+=begin original
+
+L<Test::Simple> has been upgraded from version 1.302194 to 1.302199.
+
+=end original
+
+L<Test::Simple> はバージョン 1.302194 から 1.302199 に更新されました。
+
+=item *
+
+=begin original
+
+L<Text::Tabs> has been upgraded from version 2021.0814 to 2024.001.
+
+=end original
+
+L<Text::Tabs> はバージョン 2021.0814 から 2024.001 に更新されました。
+
+=item *
+
+=begin original
+
+L<Text::Wrap> has been upgraded from version 2021.0814 to 2024.001.
+
+=end original
+
+L<Text::Wrap> はバージョン 2021.0814 から 2024.001 に更新されました。
+
+=item *
+
+=begin original
+
+L<threads> has been upgraded from version 2.36 to 2.40.
+
+=end original
+
+L<threads> はバージョン 2.36 から 2.40 に更新されました。
+
+=begin original
+
+An internal error has been made slightly more verbose
+(C<Out of memory in perl:threads:ithread_create>).
+
+=end original
+
+内部エラーがもう少し詳しくなりました
+(C<Out of memory in perl:threads:ithread_create>)。
+
+=item *
+
+=begin original
+
+L<threads::shared> has been upgraded from version 1.68 to 1.69.
+
+=end original
+
+L<threads::shared> はバージョン 1.68 から 1.69 に更新されました。
+
+=item *
+
+=begin original
+
+L<Tie::File> has been upgraded from version 1.07 to 1.09.
+
+=end original
+
+L<Tie::File> はバージョン 1.07 から 1.09 に更新されました。
+
+=begin original
+
+Old compatibility code for perl 5.005 that was no longer functional has been
+removed.
+
+=end original
+
+もはや機能しない perl 5.005 の古い互換コードは削除されました。
+
+=item *
+
+=begin original
+
+L<Time::gmtime> has been upgraded from version 1.04 to 1.05.
+
+=end original
+
+L<Time::gmtime> はバージョン 1.04 から 1.05 に更新されました。
+
+=item *
+
+=begin original
+
+L<Time::HiRes> has been upgraded from version 1.9775 to 1.9777.
+
+=end original
+
+L<Time::HiRes> はバージョン 1.9775 から 1.9777 に更新されました。
+
+=item *
+
+=begin original
+
+L<Time::Local> has been upgraded from version 1.30 to 1.35.
+
+=end original
+
+L<Time::Local> はバージョン 1.30 から 1.35 に更新されました。
+
+=item *
+
+=begin original
+
+L<Time::localtime> has been upgraded from version 1.03 to 1.04.
+
+=end original
+
+L<Time::localtime> はバージョン 1.03 から 1.04 に更新されました。
+
+=item *
+
+=begin original
+
+L<Time::tm> has been upgraded from version 1.00 to 1.01.
+
+=end original
+
+L<Time::tm> はバージョン 1.00 から 1.01 に更新されました。
+
+=item *
+
+=begin original
+
+L<UNIVERSAL> has been upgraded from version 1.15 to 1.17.
+
+=end original
+
+L<UNIVERSAL> はバージョン 1.15 から 1.17 に更新されました。
+
+=item *
+
+=begin original
+
+L<User::grent> has been upgraded from version 1.04 to 1.05.
+
+=end original
+
+L<User::grent> はバージョン 1.04 から 1.05 に更新されました。
+
+=item *
+
+=begin original
+
+L<User::pwent> has been upgraded from version 1.02 to 1.03.
+
+=end original
+
+L<User::pwent> はバージョン 1.02 から 1.03 に更新されました。
+
+=item *
+
+=begin original
+
+L<version> has been upgraded from version 0.9929 to 0.9930.
+
+=end original
+
+L<version> はバージョン 0.9929 から 0.9930 に更新されました。
+
+=item *
+
+=begin original
+
+L<warnings> has been upgraded from version 1.65 to 1.69.
+
+=end original
+
+L<warnings> はバージョン 1.65 から 1.69 に更新されました。
+
+=item *
+
+=begin original
+
+L<XS::APItest> has been upgraded from version 1.32 to 1.36.
+
+=end original
+
+L<XS::APItest> はバージョン 1.32 から 1.36 に更新されました。
+
+=item *
+
+=begin original
+
+L<XS::Typemap> has been upgraded from version 0.19 to 0.20.
+
+=end original
+
+L<XS::Typemap> はバージョン 0.19 から 0.20 に更新されました。
+
+=back
+
+=head1 Documentation
+
+(文書)
+
+=head2 Changes to Existing Documentation
+
+(既存の文書の変更)
+
+=begin original
+
+We have attempted to update the documentation to reflect the changes
+listed in this document.  If you find any we have missed, open an issue
+at L<https://github.com/Perl/perl5/issues>.
+
+=end original
+
+私たちはこの文書で挙げられた変更を反映するように文書を更新しようとしています。
+もし抜けている物を発見したら、
+L<https://github.com/Perl/perl5/issues> でイシューを開いてください。
+
+=begin original
+
+Additionally, the following selected changes have been made:
+
+=end original
+
+それに加えて、以下のような変更が行われました。
+
+=head3 L<perlapi>
+
+=over 4
+
+=item *
+
+=begin original
+
+Corrected the documentation for L<C<Perl_form>|perlapi/form>,
+C<form_nocontext>, and C<vform>, which claimed that any later call to one
+of them will destroy the previous returns from any.  This hasn't been true
+since 5.6.0, except it does remain true if these are called during global
+destruction.  With that caveat, the return of each of these is a fresh
+string in a temporary that will automatically be freed by a call to
+L<perlapi/C<FREETMPS>> or at at places such as statement boundaries.
+
+=end original
+
+L<C<Perl_form>|perlapi/form>, C<form_nocontext>, C<vform> の文書を
+修正しました; これらのいずれかを後で呼び出すと、いずれかからの以前の
+返り値が破棄されると主張していました。
+これは 5.6.0 以降は真実ではありません; 但しこれらがグローバル破壊中に
+呼び出された場合は真実のままです。
+この点に注意してください;
+これらのそれぞれの返り値は、L<perlapi/C<FREETMPS>> への呼び出しによって、
+または文境界などの場所で自動的に解放される一時的な新しい文字列です。
+
+=item *
+
+=begin original
+
+Several internal functions now have documentation - the various C<newSUB>
+functions, C<newANONLIST()>, C<newANONHASH()>, C<newSVREF()> and similar.
+
+=end original
+
+さまざまな C<newSUB> 関数、C<newANONLIST()>, C<newANONHASH()>,
+C<newSVREF()> など、いくつかの内部関数に文書が追加されました。
+
+=back
+
+=head3 L<perlclass>
+
+=over 4
+
+=item *
+
+=begin original
+
+Added a list of known bugs in the experimental C<class> feature.
+
+=end original
+
+実験的な C<class> 機能での既知のバグの一覧が追加されました。
+
+=back
+
+=head3 L<perlfunc>
+
+=over 4
+
+=item *
+
+=begin original
+
+The documentation for L<C<local>|perlfunc/local EXPR>,
+L<C<my>|perlfunc/my VARLIST>, L<C<our>|perlfunc/our VARLIST>, and
+L<C<state>|perlfunc/state VARLIST>, has been updated to include examples
+and descriptions of their effects within a statement.
+
+=end original
+
+L<C<local>|perlfunc/local EXPR>, L<C<my>|perlfunc/my VARLIST>,
+L<C<our>|perlfunc/our VARLIST>, L<C<state>|perlfunc/state VARLIST> の
+文書が更新され、一つの文の中にその効果の例と説明が追加されました。
+
+=back
+
+=head3 L<perlguts>
+
+=over 4
+
+=item *
+
+=begin original
+
+A new section has been added which describes the experimental
+reference-counted argument stack build option (C<PERL_RC_STACK>).
+
+=end original
+
+実験的な、参照カウントされる引数スタックのビルドオプション
+(C<PERL_RC_STACK>) を記述する新しい節が追加されました。
+
+=back
+
+=back
+
+=head3 L<perlclib>
+
+=over 4
+
+=item *
+
+=begin original
+
+Extensive guidance has been added for interfacing with the standard C
+library, including many more functions to avoid, and how to cope with
+locales and threads.
+
+=end original
+
+より多くの避けるべき関数や、ロケールとスレッドとの付き合い方といった、
+標準 C ライブラリとの接続に関する幅広いガイドが追加されました。
+
+=head3 L<perlhacktips>
+
+=over 4
+
+=item *
+
+=begin original
+
+Document we can't use compound literals or array designators due to C++
+compatibility.  [L<GH #21073|https://github.com/Perl/perl5/issues/21073>]
+
+=end original
+
+C++ の互換性のため、複合リテラルや配列指定子は使えないことを文書化しました。
+[L<GH #21073|https://github.com/Perl/perl5/issues/21073>]
+
+=item *
+
+=begin original
+
+Document new functions C<sv_mark_arenas()> and C<sv_sweep_arenas()>
+(which only exist on C<DEBUGGING> builds)
+
+=end original
+
+新しい関数 C<sv_mark_arenas()> と C<sv_sweep_arenas()>(これらは
+C<DEBUGGING> ビルドにのみ存在します)を文書化しました。
+
+=item *
+
+=begin original
+
+Added brief documentation for some tools useful when developing perl
+itself on Windows or Cygwin.
+
+=end original
+
+Windows や Cygwin 上で perl 自身を開発する際に役立ついくつかのツールの
+簡単な説明を追加しました。
+
+=back
+
+=head3 L<perllol>
+
+=over 4
+
+=item *
+
+=begin original
+
+Removed indirect object syntax in C<Dumpvalue> example
+
+=end original
+
+C<Dumpvalue> の例から間接オブジェクト構文が削除されました。
+
+=back
+
+=head3 L<perlre>
+
+=over 4
+
+=item *
+
+=begin original
+
+Removed statement suggesting C</p> is a no-op.
+
+=end original
+
+C</p> が何もしないことを示唆する文が削除されました。
+
+=back
+
+=head3 L<perlref>
+
+=over 4
+
+=item *
+
+=begin original
+
+Documented ref assignment in list context (as part of the C<refaliasing> feature)
+
+=end original
+
+(C<refaliasing> 機能の一部としての)リストコンテキスト内のリファレンス代入を
+文書化しました。
+
+=back
+
+=head3 L<perlop>
+
+=over 4
+
+=item *
+
+=begin original
+
+The section on the empty pattern C<//> has been amended to mention that the current dynamic scope is
+used to find the last successful match.
+
+=end original
+
+空のパターン C<//> の節が修正され、現在の動的スコープが最後の成功した
+マッチングを見つけるために使われることに言及しました。
+
+=back
+
+=head3 L<perlport>
+
+=over 4
+
+=item *
+
+=begin original
+
+The C<-S> file test has been meaningful on Win32 since 5.37.6
+
+=end original
+
+C<-S> のファイルテストは、5.37.6 から Win32 で有効になっています。
+
+=item *
+
+=begin original
+
+The C<-l> file test is now meaningful on Win32
+
+=end original
+
+C<-l> ファイルテストが Win32 で有効になりました。
+
+=item *
+
+=begin original
+
+Some strange behaviour with C<.> at the end of names under Windows has been documented
+
+=end original
+
+Windows で名前の最後に C<.> を使ったときの奇妙な振る舞いについて
+文書化されました。
+
+=back
+
+=head3 L<perlvar>
+
+=over 4
+
+=item *
+
+=begin original
+
+Added documentation for an alternative to C<${^CAPTURE}>
+
+=end original
+
+C<${^CAPTURE}> の代替に関する文書が追加されました。
+
+=back
+
+=head1 Diagnostics
+
+(診断メッセージ)
+
+=begin original
+
+The following additions or changes have been made to diagnostic output,
+including warnings and fatal error messages.  For the complete list of
+diagnostic messages, see L<perldiag>.
+
+=end original
+
+次のような追加と変更が、警告や致命的エラーメッセージを含む診断出力に
+行われました。
+診断メッセージの完全な一覧については、L<perldiag> を参照してください。
+
+=head2 New Diagnostics
+
+(新しい警告メッセージ)
+
+=head3 New Errors
+
+(新しいエラー)
+
+=over 4
+
+=item *
+
+L<Cannot use __CLASS__ outside of a method or field initializer expression|perldiag/"Cannot use __CLASS__ outside of a method or field initializer expression">
+
+=begin original
+
+(F) A C<__CLASS__> expression yields the class name of the object instance
+executing the current method, and therefore it can only be placed inside an
+actual method (or method-like expression, such as a field initializer
+expression).
+
+=end original
+
+(F) C<__CLASS__> 式は、現在のメソッドを実行するオブジェクトインスタンスの
+クラス名を生成するので、実際のメソッド(または、フィールド初期化式などの
+メソッド風の式)の中にのみ配置できます。
+
+=item *
+
+L<get_layers: unknown argument '%s'|perldiag/"get_layers: unknown argument '%s'">
+
+=begin original
+
+(F) You called PerlIO::get_layers() with an unknown argument. Legal
+arguments are provided in key/value pairs, with the keys being one
+of C<input>, C<output> or C<detail>, followed by a boolean.
+
+=end original
+
+(F) あなたは未知の引数 でPerlIO::get_layers() を呼び出しました。
+有効な引数はキーと値のペアで提供され、キーは C<input>, C<output>,
+C<detail> のいずれかで、その後に真偽値が続きます。
+
+=item
+
+L<UNIVERSAL does not export anything|perldiag/"UNIVERSAL does not export anything">
+
+=begin original
+
+(F) You asked UNIVERSAL to export something, but UNIVERSAL is the
+base class for all classes and contains no exportable symbols.
+
+=end original
+
+(F) UNIVERSAL に何かをエクスポートするように要求しましたが、
+UNIVERSAL はすべてのクラスの基底クラスであり、
+エクスポート可能なシンボルを含んでいません。
+
+=item *
+
+L<Builtin version bundle "%s" is not supported by Perl|perldiag/Builtin version bundle "%s" is not supported by Perl>
+
+=begin original
+
+(F) You attempted to C<use builtin :ver> for a version number that is either
+older than 5.39 (when the ability was added), or newer than the current perl
+version.
+
+=end original
+
+(F) バージョン番号が 5.39 (機能が追加されたとき)より古いか、
+現在の perl バージョンより新しいバージョン番号に対して
+C<use builtin :ver> を実行しようとしました。
+
+=item *
+
+L<Invalid version bundle "%s"|perldiag/Invalid version bundle "%s">
+
+=begin original
+
+(F) A version number that is used to specify an import bundle during a
+C<use builtin ...> statement must be formatted as C<:MAJOR.MINOR> with an
+optional third component, which is ignored.  Each component must be a number
+of 1 to 3 digits. No other characters are permitted.  The value that was
+specified does not conform to these rules.
+
+=end original
+
+(F) C<use builtin ...> 文中にインポートバンドルを指定するために
+使われるバージョン番号は、C<:MAJOR.MINOR> として
+フォーマットしなければなりません。
+オプションの 3 番目のコンポーネントは無視されます。
+各コンポーネントは 1 から 3 桁の数字でなければなりません。
+他の文字は使えません。
+指定された値はこれらの規則に従っていません。
+
+=item *
+
+L<Missing comma after first argument to return|perldiag/"Missing comma after first argument to return">
+
+=begin original
+
+(F) While certain operators allow you to specify a filehandle or an
+"indirect object" before the argument list, C<return> isn't one of
+them.
+
+=end original
+
+(F) 特定の演算子では、引数リストの前にファイルハンドルまたは
+「間接オブジェクト」を指定できますが、C<return> はその一つではありません。
+
+=item *
+
+L<Out of memory during vec in lvalue context|perldiag/"Out of memory during vec in lvalue context">
+
+=begin original
+
+(F) An attempt was made to extend a string beyond the largest possible memory
+allocation by assigning to C<vec()> called with a large second argument.
+
+=end original
+
+(F) 大きな 2 番目の引数で呼び出された C<vec()> に代入することによって、
+可能な最大のメモリ割り当てを超えて文字列を拡張しようとしました。
+
+=begin original
+
+(This case used to throw a generic C<Out of memory!> error.)
+
+=end original
+
+(このケースでは、以前は一般的な C<Out of memory!> エラーが投げられていました。)
+
+=item *
+
+L<Cannot create an object of incomplete class "%s"|perldiag/"Cannot create an object of incomplete class "%s"">
+
+=begin original
+
+(F) An attempt was made to create an object of a class where the start
+of the class definition has been seen, but the class has not been
+completed.
+
+=end original
+
+(F) クラス定義の開始が確認されたクラスのオブジェクトを作成しようとしましたが、
+クラスが完了していません。
+
+=begin original
+
+This can happen for a failed eval, or if you attempt to create an
+object at compile time before the class is complete:
+
+=end original
+
+これは、失敗した eval、またはクラスが完了する前のコンパイル時にオブジェクトを
+作成しようとした場合に発生する可能性があります。
+
+  eval "class Foo {"; Foo->new; # error
+  class Bar { BEGIN { Bar->new } }; # error
+
+=begin original
+
+Previously perl would assert or crash. [L<GH #22159|https://github.com/Perl/perl5/issues/22159>]
+
+=end original
+
+これまでの perl はアサートやクラッシュを起こしていました。
+[L<GH #22159|https://github.com/Perl/perl5/issues/22159>]
+
+=back
+
+=head3 New Warnings
+
+(新しい警告)
+
+=over 4
+
+=item *
+
+L<< Forked open '%s' not meaningful in <>|perldiag/"Forked open '%s' not meaningful in <>" >>
+
+=begin original
+
+(S inplace) You had C<|-> or C<-|> in C<@ARGV> and tried to use C<< <>
+>> to read from it.
+
+=end original
+
+(S inplace) C<@ARGV> に C<|-> または C<-|> があり、C<< <> >> を使って
+それを読み取ろうとしました。
+
+=begin original
+
+Previously this would fork and produce a confusing error message. [L<GH #21176|https://github.com/Perl/perl5/issues/21176>]
+
+=end original
+
+これまでは、これが分岐して紛らわしいエラーメッセージが表示されていました。
+[L<GH #21176|https://github.com/Perl/perl5/issues/21176>]
+
+=item *
+
+L<Attempt to call undefined %s method with arguments ("%s"%s) via package "%s" (Perhaps you forgot to load the package?)|perldiag/Attempt to call undefined %s method with arguments ("%s"%s) via package "%s" (Perhaps you forgot to load the package?)>
+
+=begin original
+
+(D deprecated::missing_import_called_with_args) You called the
+C<import()> or C<unimport()> method of a class that has no import method
+defined in its inheritance graph, and passed an argument to the method.
+This is very often the sign of a misspelled package name in a use or
+require statement that has silently succeeded due to a case insensitive
+file system.
+
+=end original
+
+(D deprecated::missing_import_called_with_args) 継承グラフに
+インポートメソッドが定義されていないクラスの C<import()> または
+C<unimport()> メソッドを呼び出し、そのメソッドに引数を渡しました。
+これは多くの場合、use 文または require 文の中で、大文字と小文字を区別しない
+ファイルシステムのために暗黙的に成功したパッケージ名のスペルミスの兆候です。
+
+=begin original
+
+Another common reason this may happen is when mistakenly attempting to
+import or unimport a symbol from a class definition or package which
+does not use C<Exporter> or otherwise define its own C<import> or
+C<unimport> method.
+
+=end original
+
+これが発生するもう一つの一般的な理由は、C<Exporter> を使わないか、
+独自の C<import> または C<unimport> メソッドを定義していないクラス定義または
+パッケージから、誤ってシンボルをインポートまたは
+インポート解除しようとした場合です。
+
+=back
+
+=head2 Changes to Existing Diagnostics
+
+(既存の診断メッセージの変更)
+
+=over 4
+
+=item *
+
+L<Name "%s::%s" used only once: possible typo|perldiag/"Name "%s::%s" used only once: possible typo">
+
+=begin original
+
+This warning now honors being marked as fatal.  [L<GH #13814|https://github.com/Perl/perl5/issues/13814>]
+
+=end original
+
+この警告は致命的とマークされるようになりました。
+[L<GH #13814|https://github.com/Perl/perl5/issues/13814>]
+
+=item *
+
+L<Out of memory in perl:%s|perldiag/"Out of memory in perl:%s">
+
+=begin original
+
+There used to be several places in the perl core that would print a generic
+C<Out of memory!> message and abort when memory allocation failed, giving no
+indication which program it was that ran out of memory.  These have been
+modified to include the word C<perl> and the general area of the allocation
+failure, e.g. C<Out of memory in perl:util:safesysrealloc>.  [L<GH #21672|https://github.com/Perl/perl5/issues/21672>]
+
+=end original
+
+Perl コアには以前、一般的な C<Out of memory!> メッセージを出力して、
+メモリ割り当てが失敗したときにメモリを使い果たしたプログラムを表示せずに
+中断する場所がいくつかありました。
+これらは、C<perl> という語と割り当て失敗の一般的な領域を含むように
+修正されました;
+例えば、C<Out of memory in perl:util:safesysrealloc>。
+[L<GH #21672|https://github.com/Perl/perl5/issues/21672>]
+
+=item *
+
+L<Possible precedence issue with control flow operator (%s)|perldiag/"Possible precedence issue with control flow operator (%s)">
+
+=begin original
+
+This warning now mentions the name of the control flow operator that triggered
+the diagnostic (e.g. C<return>, C<exit>, C<die>, etc).
+
+=end original
+
+この警告では、診断を引き起こした制御フロー演算子の名前
+(C<return>, C<exit>, C<die> など)が示されるようになりました。
+
+=begin original
+
+It also covers more cases: Previously, the warning was only triggered if a
+low-precedence logical operator (like C<and>, C<or>, C<xor>) was involved.  Now
+it is also shown for misleading code like this:
+
+=end original
+
+また、より多くの状況に対応するようになりました:
+これまでは、(C<and>, C<or>, C<xor> のような)優先順位の低い論理演算子が
+含まれている場合にのみ警告が発生していました。
+次のような誤解を招くコードにも表示されるようになりました:
+
+    exit $x ? 0 : 1;  # actually parses as: exit($x) ? 0 : 1;
+    exit $x == 0;     # actually parses as: exit($x) == 0;
+
+=item *
+
+L<Use of uninitialized value%s|perldiag/"Use of uninitialized value%s">
+
+=begin original
+
+This warning is now slightly more accurate in cases involving C<length>,
+C<pop>, C<shift>, or C<splice>:
+
+=end original
+
+この警告は、C<length>, C<pop>, C<shift>, C<splice> に関する場合に、
+さらに若干正確になりました:
+
+    my $x;
+    length($x) == 0
+    # Before:
+    #  Use of uninitialized value $x in numeric eq (==) at ...
+    # Now:
+    #  Use of uninitialized value length($x) in numeric eq (==) at ...
+
+=begin original
+
+That is, the warning no longer implies that C<$x> was used directly as an
+operand of C<==>, which it wasn't.
+
+=end original
+
+つまり、この警告は、C<$x> が C<==> のオペランドとして直接使われたことを
+意味するものではもはやなくなりました。
+
+=begin original
+
+Similarly:
+
+=end original
+
+同様に:
+
+    my @xs;
+    shift @xs == 0
+    # Before:
+    #  Use of uninitialized value within @xs in numeric eq (==) at ...
+    # Now:
+    #  Use of uninitialized value shift(@xs) in numeric eq (==) at ...
+
+=begin original
+
+This is more accurate because there never was an C<undef> within C<@xs> as the
+warning implied. (The warning for C<pop> works analogously.)
+
+=end original
+
+以前の警告が暗示していたように C<@xs> の中身が C<undef> である
+訳ではないので、これはより正確です。
+(C<pop> の警告も同様に動作します。)
+
+=begin original
+
+Finally:
+
+=end original
+
+最後に:
+
+    my @xs = (1, 2, 3);
+    splice(@xs, 0, 0) == 0
+    # Before:
+    #  Use of uninitialized value within @xs in numeric eq (==) at ...
+    # Now:
+    #  Use of uninitialized value in numeric eq (==) at ...
+
+=begin original
+
+That is, in cases where C<splice> returns C<undef>, it no longer
+unconditionally blames its first argument. This was misleading because
+C<splice> can return C<undef> even if none of its arguments contain C<undef>.
+
+=end original
+
+つまり、C<splice> が C<undef> を返す場合、
+もはや最初の引数を無条件に非難しなくなりました。
+C<splice> は、その引数に C<undef> が含まれていなくても C<undef> を
+返すことがあるため、これは誤解を招くものでした。
+
+[L<GH #21930|https://github.com/Perl/perl5/issues/21930>]
+
+=item *
+
+L<Old package separator "'" deprecated|perldiag/"Old package separator "'" deprecated">
+
+=begin original
+
+Prevent this warning appearing spuriously when checking the heuristic for the
+L<You need to quote "%s"|perldiag/"You need to quote "%s""> warning.
+
+=end original
+
+L<You need to quote "%s"|perldiag/"You need to quote "%s""> 警告のための
+ヒューリスティックをチェックするときに、この警告が誤って
+表示されないようになりました。
+
+[L<GH #22145|https://github.com/Perl/perl5/issues/22145>]
+
+=back
+
+=head1 Configuration and Compilation
+
+(設定とコンパイル)
+
+=over 4
+
+=item *
+
+=begin original
+
+C<microperl>, long broken and of unclear present purpose, has been removed
+as promised in L<Perl 5.18|perl5180delta/Future Deprecations>.
+
+=end original
+
+L<Perl 5.18|perl5180delta/Future Deprecations> で約束されたように、
+長い間壊れていて現在の目的が不明確な C<microperl> は削除されました。
+
+=item *
+
+=begin original
+
+Fix here-doc used for code to probe C<LC_ALL> syntax for disparate
+locales introduced in 5.39.2.  [L<GH #21451|https://github.com/Perl/perl5/issues/21451>]
+
+=end original
+
+5.39.2 で導入された、異なるロケールのための C<LC_ALL> 構文を
+調べるためのコードのために使われていた日やドキュメントが修正されました。
+[L<GH #21451|https://github.com/Perl/perl5/issues/21451>]
+
+=item *
+
+=begin original
+
+You can now separately enable high water mark checks for non-DEBUGGING
+or disable them for DEBUGGING builds with C<-Accflags=-DPERL_USE_HWM>
+or C<-Accflags=-DPERL_NO_HWM> respectively.  The default remains the
+same.  [L<GH #16607|https://github.com/Perl/perl5/issues/16607>]
+
+=end original
+
+C<-Accflags=-DPERL_USE_HWM> または C<-Accflags=-DPERL_NO_HWM> を使った、
+非 DEBUGGING ビルドの High Watermark チェックを個別に有効または
+無効にできるようになりました。
+デフォルトは同じです。
+[L<GH #16607|https://github.com/Perl/perl5/issues/16607>]
+
+=back
+
+=head1 Testing
+
+(テスト)
+
+=begin original
+
+Tests were added and changed to reflect the other additions and
+changes in this release.  Furthermore, these significant changes were
+made:
+
+=end original
+
+このリリースのその他の追加と変更を反映してテストが追加、変更されました。
+さらに、主に以下のような変更が行われました:
+
+=over 4
+
+=item *
+
+=begin original
+
+Update F<nm> output parsing for Darwin in F<t/porting/libperl.t> to handle
+changes in the output of nm on Darwin.
+[L<GH #21117|https://github.com/Perl/perl5/issues/21117>]
+
+=end original
+
+Darwin での F<nm> の出力の変更を扱うために、
+F<t/porting/libperl.t> 内の Darwin のための nm の出力のパースを更新しました。
+[L<GH #21117|https://github.com/Perl/perl5/issues/21117>]
+
+=item *
+
+=begin original
+
+F<t/op/magic.t> would fail when C<ps> was the BusyBox implementation,
+since that doesn't support the C<-p> flag and otherwise ignores a
+process id on the command-line.  This caused F<TEST> failures on
+BusyBox systems such as Alpine Linux.  [L<GH #17542|https://github.com/Perl/perl5/issues/17542>]
+
+=end original
+
+C<ps> が BusyBox の実装である場合、F<t/op/magic.t> は失敗します。
+これは、C<-p> フラグに対応しておらず、コマンドライン上のプロセス ID が
+無視されるためです。
+これにより、Alpine Linux などの BusyBox システムで F<TEST> エラーを
+引き起こししていました。
+[L<GH #17542|https://github.com/Perl/perl5/issues/17542>]
+
+=item *
+
+=begin original
+
+F<porting/globvar.t> now uses the more portable C<nm -P ...> to fetch
+the names defined in an object file.  The parsing of the names found
+in the object is now separated from processing them to handle the
+duplication between local and global definitions on AIX.  [L<GH #21637|https://github.com/Perl/perl5/issues/21637>]
+
+=end original
+
+F<porting/globvar.t> は、オブジェクトファイルで定義された名前を
+フェッチするために、より移植性の高い C<nm -P ...> を
+使うようになりました。
+オブジェクト内で見つかった名前の解析は、AIX 上のローカル定義と
+グローバル定義の間の重複を扱うための処理から分離されました。
+[L<GH #21637|https://github.com/Perl/perl5/issues/21637>]
+
+=item *
+
+=begin original
+
+A test was added to F<lib/locale_threads.t> that extensively stress
+tests locale handling.  It turns out that the libc implementations on
+various platforms have bugs in this regard, including Linux, Windows,
+*BSD derivatives including Darwin, and others.  Experimental versions of
+this test have been used in the past few years to find bugs in the Perl
+implementation and in those platforms, as well as to develop workarounds
+in the Perl implementation, where feasible, for the platform bugs.
+Multiple bug report tickets have been filed against platforms, and some
+have been fixed.  The test checks that platforms that purport to support
+thread-safe locale handling actually do so (and that perl works properly
+on those that do;  The read-only variable C<${^SAFE_LOCALES}> is set to
+1 if perl thinks the platform can handle this, whatever the platform's
+documentation says).
+
+=end original
+
+F<lib/locale_threads.t> に、
+ロケールの扱いを詳細にテストするテストが追加されました。
+Linux, Windows, Darwin などの *BSD 派生物など、さまざまな
+プラットフォームでの libc 実装には、この点に関してバグがあることが
+判明しています。
+このテストの実験版は、過去数年間、Perl 実装とそれらの
+プラットフォームのバグを発見するため、
+また、可能な場合には、プラットフォームのバグに対する Perl 実装の
+回避策を開発するために使われてきました。
+プラットフォームに対して複数のバグレポートチケットが提出され、
+いくつかが修正されています。
+このテストでは、スレッドセーフなロケール処理をサポートすることを意図した
+プラットフォームが実際にそうしていることを
+チェックします(また、スレッドセーフなロケール処理をサポートしている
+プラットフォームで perl が正しく動作することもチェックします;
+プラットフォームの文書にどのように記されているかに関わらず、
+perl がプラットフォームがこれを処理できると判断した場合は、
+読み取り専用変数 C<${^SAFE_LOCALES}> が 1 に設定されます)。
+
+=begin original
+
+Also tested for is if the various locale categories can indeed be set
+independently to disparate locales.  (An example of where you might want
+to do this is if you are a Western Canadian living and working in
+Holland.  You likely will want to have the C<LC_MONETARY> locale be
+set to where you are living, but have the other parts of your locale
+retain your native English values.  Later, as you get a bit more
+comfortable with Dutch, and in order to communicate better with your
+colleagues, you might want to change C<LC_TIME> and C<LC_NUMERIC> to
+Dutch, while leaving C<LC_CTYPE> and C<LC_COLLATE> set to English
+indefinitely.)
+
+=end original
+
+また、さまざまなロケールカテゴリが、実際に異なるロケールに対して独立して
+設定できるかどうかもテストされます(これがほしいと思われる一つの例として、
+あなたがオランダに住んで働いている西カナダ人とします。
+C<LC_MONETARY> ロケールを現在住んでいる場所に設定し、
+ロケールの他の部分はネイティブの英語の値を保持することができます。
+その後、オランダ語に少し慣れてきて、同僚とのコミュニケーションを
+良くするために、C<LC_TIME> と C<LC_NUMERIC> をオランダ語に変更し、
+C<LC_CTYPE> と C<LC_COLLATE> を無期限に
+英語に設定したままにすることができます)。
+
+=item *
+
+=begin original
+
+The test F<t/porting/libperl.t> will no longer run in maint releases.
+This test is sensitive to changes in the output of F<nm> on various
+platforms, and tarballs aren't updated as we update this test in
+blead.  [L<GH #21677|https://github.com/Perl/perl5/issues/21677>]
+
+=end original
+
+テスト F<t/porting/libperl.t> は、メンテナンスリリースでは
+もはや実行されません。
+このテストは、さまざまなプラットフォームでの F<nm> の出力の変化に
+敏感であり、blead でこのテストを更新しても tarball は更新されません。
+[L<GH #21677|https://github.com/Perl/perl5/issues/21677>]
+
+=back
+
+=head1 Platform Support
+
+(プラットフォーム対応)
+
+=head2 New Platforms
+
+(新しいプラットフォーム)
+
+=over 4
+
+=item Serenity OS
+
+=begin original
+
+Out of the box support for Serenity OS was added.
+
+=end original
+
+すぐに使える Serenity OS 対応が追加されました。
+
+=back
+
+=head2 Platform-Specific Notes
+
+(プラットフォーム固有の注意)
+
+=over 4
+
+=item Windows
+
+=begin original
+
+Eliminated several header build warnings under MSVC with C</W4> to reduce noise
+for embedders.  [L<GH #21031|https://github.com/Perl/perl5/issues/21031>]
+
+=end original
+
+C</W4> を使用した MSVC でのいくつかのヘッダビルド警告を削除し、
+埋め込み用のノイズを低減しました。
+[L<GH #21031|https://github.com/Perl/perl5/issues/21031>]
+
+=begin original
+
+Work around a bug in most 32-bit Mingw builds, where the generated
+code, including the code in the gcc support library, assumes 16-byte
+stack alignment, which 32-bit Windows does not preserve. [L<GH #21313|https://github.com/Perl/perl5/issues/21313>]
+
+=end original
+
+ほとんどの 32 ビット Mingw ビルドのバグを回避しました;
+これは、gcc サポートライブラリ内のコードを含む生成されたコードは、
+32 ビット Windows では保持されない 16 バイトのスタックアライメントを
+前提としているというものです。
+[L<GH #21313|https://github.com/Perl/perl5/issues/21313>]
+
+=begin original
+
+Enable C<copysign>, C<signbit>, C<acosh>, C<asinh>, C<atanh>, C<exp2>,
+C<tgamma> in the bundled configuration used for MSVC.  [L<GH #21610|https://github.com/Perl/perl5/issues/21610>]
+
+=end original
+
+MSVC に使われる組み込みの設定で、
+C<copysign>, C<signbit>, C<acosh>, C<asinh>, C<atanh>, C<exp2>,
+C<tgamma> を有効にしました。
+[L<GH #21610|https://github.com/Perl/perl5/issues/21610>]
+
+=begin original
+
+The build process no longer supports Visual Studio 2013.  This was
+failing to build at a very basic level and there have been no reports
+of such failures.  [L<GH #21624|https://github.com/Perl/perl5/issues/21624>]
+
+=end original
+
+ビルドプロセスは Visual Studio 2013 に対応しなくなりました。
+これは非常に基本的なレベルでのビルドに失敗しており、そのような
+失敗の報告はありませんでした。
+[L<GH #21624|https://github.com/Perl/perl5/issues/21624>]
+
+=item Linux
+
+=begin original
+
+The hints file has been updated to handle the Intel oneAPI DPC++/C++ compiler.
+
+=end original
+
+ヒントファイルが更新され、Intel oneAPI DPC++/C++ コンパイラを
+扱えるようになりました。
+
+=item MacOS/Darwin
+
+=begin original
+
+Don't set C<MACOSX_DEPLOYMENT_TARGET> when building on OS X 10.5.  [L<GH
+#21367|https://github.com/Perl/perl5/issues/21367>]
+
+=end original
+
+Mac OSX 10.5 上でビルドする場合は、C<MACOSX_DEPLOYMENT_TARGET> を
+設定しなくなりました。
+[L<GH #21367|https://github.com/Perl/perl5/issues/21367>]
+
+=item VMS
+
+=begin original
+
+Fixed the configure "installation prefix" prompt to accept a string rather than
+yes/no.
+
+=end original
+
+configure の "installation prefix" プロンプトが、yes/no ではなく文字列を
+受け入れるように修正されました。
+
+=begin original
+
+Fixed compilation by defining proper value for
+C<perl_lc_all_category_positions_init>.
+
+=end original
+
+C<perl_lc_all_category_positions_init> に適切な値を定義することで、
+コンパイルが修正されました。
+
+=begin original
+
+Increased buffer size when reading F<config_H.SH> to fix compilation under
+clang.
+
+=end original
+
+F<config_H.SH> を読み込む際のバッファサイズを増やし、clang の下での
+コンパイルを修正しました。
+
+=item Oracle Developer Studio (Solaris, Oracle Linux)
+
+=begin original
+
+Due to an apparent code generation bug, the default optimization level
+for the Oracle Developer Studio (formerly Sun Workshop) compiler is
+now C<-xO1>. [L<GH #21535|https://github.com/Perl/perl5/issues/21535>]
+
+=end original
+
+明らかなコード生成のバグにより、Oracle Developer Studio(以前の
+Sun Workshop)コンパイラのデフォルトの最適化レベルは C<-xO1> になりました。
+[L<GH #21535|https://github.com/Perl/perl5/issues/21535>]
+
+=back
+
+=head1 Internal Changes
+
+(内部の変更)
+
+=over 4
+
+=item *
+
+=begin original
+
+C<PERL_RC_STACK> build option added.
+
+=end original
+
+C<PERL_RC_STACK> ビルドオプションが追加されました。
+
+=begin original
+
+This new build option is highly experimental and is not enabled by
+default. Perl can be built with it by using the F<Configure> option
+C<-Accflags='-DPERL_RC_STACK'>.
+
+=end original
+
+この新しいビルドオプションは非常に実験的なものであり、デフォルトでは
+有効になっていません。
+F<Configure> オプション C<-Accflags='-DPERL_RC_STACK'> を使うことで、
+このオプションを使って Perl をビルドできます。
+
+=begin original
+
+It makes the argument stack bump the reference count of SVs pushed onto
+it. It is mostly functional, but currently slow and incomplete.
+
+=end original
+
+これは、引数スタックにプッシュされた SV の参照カウントをバンプさせます。
+ほとんどは機能しますが、現在は遅く不完全です。
+
+=begin original
+
+It is intended in the long term that this build option will become
+the default option, and then finally the only option; but this will be
+many releases away.
+
+=end original
+
+長期的には、このビルドオプションがデフォルトオプションになり、
+最終的には唯一のオプションになることが意図されています;
+しかしこれには多くのリリースがかかる予定です。
+
+=begin original
+
+In particular, there is currently no support within XS code for using
+these new features. So under this build option, all XS functions are
+called via a backwards-compatibility wrapper which slows down such calls.
+
+=end original
+
+特に、現在 XS コード内でこれらの新機能を使うためのサポートがありません。
+そのため、このビルドオプションの下では、すべての XS 関数は下位互換性のある
+ラッパーを介して呼び出されるため、そのような呼び出しが遅くなります。
+
+=begin original
+
+In future releases, better support for XS code is intended to be added.
+It is expected that straightforward XS code will eventually be able to
+make use of a reference-counted stack without modification, with any heavy
+lifting being handled by the XS compiler (C<xsubpp>) and the macros which
+it outputs. But code which implements PP() functions will eventually have
+to be modified to use a new PP API: rpp_foo() rather than PUSHs() etc. But
+this new API is not yet stable, nor has it yet been back-ported via
+C<Devel::PPPort>.
+
+=end original
+
+将来のリリースでは、XS コードのサポートが強化される予定です。
+単純な XS コードは、最終的には修正なしで参照カウントされたスタックを
+利用できるようになり、重い処理は XS コンパイラ(C<xsubpp>)とそれが出力する
+マクロによって処理されることが期待されています。
+しかし、PP() 関数を実装するコードは、最終的には新しい PP API を使うように
+修正する必要があります: PUSHs() などではなく rpp_foo() です。
+しかし、この新しい API はまだ安定しておらず、C<Devel::PPPort> を介して
+バックポートされてもいません。
+
+=begin original
+
+See L<perlguts|perlguts/"Reference-counted argument stack"> for more
+details.
+
+=end original
+
+さらなる詳細については、
+L<perlguts|perlguts/"Reference-counted argument stack"> を参照してください。
+
+=item *
+
+=begin original
+
+A new API function has been added that simplifies C (or XS) code that creates
+C<LISTOP> optree fragments.  C<newLISTOPn()> is a variadic function that takes
+a C<NULL>-terminated list of child op pointers, and constructs a new checked
+C<LISTOP> to contain them all.  This is simpler than creating a new plain
+C<OP_LIST>, adding each child individually, and finally calling
+C<op_convert_list()> in most code fragments.
+
+=end original
+
+C<LISTOP> op 木要素を作る C(または XS)コードを簡略化する、新しい
+API 関数が追加されました。
+C<newLISTOPn()> は、C<NULL> で終端された子 op ポインタのリストを取り、
+それら全てを含む新しいチェック済み C<LISTOP> を構築する可変関数です。
+これは、新しいプレーンな C<OP_LIST> を作成し、それぞれの子を個別に追加し、
+最後にほとんどのコード要素で C<op_convert_list()> を呼び出すよりも
+より簡単です。
+
+=item *
+
+=begin original
+
+The C<eval_sv()> API now accepts the C<G_USEHINTS> flag, which uses
+the hints such as strict and features from C<PL_curcop> instead of the
+default, which is to use default hints, e.g. no C<use vX.XX;>, no
+strict, default features.
+
+=end original
+
+C<eval_sv()> API が C<G_USEHINTS> フラグを受け入れるようになりました;
+このフラグは、デフォルトではなく、C<PL_curcop> の strict や
+features などのヒントを使います;
+デフォルトでは、no C<use vX.XX;>, no strict, デフォルトの機能といった
+デフォルトのヒントを使います。
+
+=begin original
+
+Beware if you use this flag in XS code: your evaluated code will need
+to support whatever strictness or features are in effect at the point
+your XS function is called.
+
+=end original
+
+XS コードでこのフラグを使う場合は注意してください:
+評価されたコードは、XS 関数が呼び出された時点で有効な strict 性や機能に
+対応する必要があります。
+
+[L<GH #21415|https://github.com/Perl/perl5/issues/21415>]
+
+=item *
+
+=begin original
+
+C<PERL_VERSION_LE> has been fixed to properly check for "less than or equal"
+rather than "less than".
+
+=end original
+
+C<PERL_VERSION_LE> が "less than" ではなく "less than or equal" を正しく
+チェックするように修正されました。
+
+=item *
+
+=begin original
+
+C<dAX>, C<dITEMS> and hence C<dXSARGS> now declare C<AX> and C<items>
+as C<Stack_off_t> rather than C<SSize_t>.  This reverts back to
+compatibility with pre-64-bit stack support for default builds of perl
+where C<Stack_off_t> is C<I32>.  [L<GH #21782|https://github.com/Perl/perl5/issues/21782>]
+
+=end original
+
+C<dAX>, C<dITEMS>, そして C<dXSARGS> は、C<AX> と C<items> を
+C<SSize_t> ではなく C<Stack_off_t> として宣言するようになりました。
+これにより、C<Stack_off_t> が C<I32> である perl のデフォルトビルドに対する
+64 ビット以前のスタックサポートとの互換性に戻ります。
+[L<GH #21782|https://github.com/Perl/perl5/issues/21782>]
+
+=item *
+
+=begin original
+
+A new function is now available to C<XS> code, L<perlapi/sv_langinfo>.
+This provides the same information as the existing
+L<perlapi/Perl_langinfo8>, but returns an SV instead of a S<C<char *>>,
+so that programmers don't have to concern themselves with the UTF-8ness
+of the result.  This new function is now the preferred interface for
+C<XS> code to the L<nl_langinfo(3)> C<libc> function.  From Perl space,
+this information continues to be provided by the L<I18N::Langinfo>
+module.
+
+=end original
+
+C<XS> コードで L<perlapi/sv_langinfo> という新しい関数が
+利用可能になりました。
+これは既存の L<perlapi/Perl_langinfo8> と同じ情報を提供しますが、
+S<C<char *>> の代わりに SV を返すので、プログラマは結果の UTF-8 性を
+気にする必要がありません。
+この新しい関数は、C<XS> コードから L<nl_langinfo(3)> C<libc> 関数への
+優先インタフェースになりました。
+Perl 空間からは、この情報は引き続き L<I18N::Langinfo> モジュールによって
+提供されます。
+
+=item *
+
+=begin original
+
+glibc has an undocumented equivalent function to querylocale(), which
+our experience indicates is reliable. When this is function is used,
+it removes the need for perl to keep its own records, hence is more
+efficient and guaranteed to be accurate. Use of this function can be
+disabled by defining the C<NO_NL_LOCALE_NAME> build option
+
+=end original
+
+glibc には文書化されていない querylocale() と同等の関数がありますが、
+これは私たちの経験から信頼できることが示されています。
+この関数を使うと、perl が独自の記録を保持する必要がなくなるため、
+より効率的で正確であることが保証されます。
+この関数の使用は、C<NO_NL_LOCALE_NAME> ビルドオプションを
+定義することで無効にできます。
+
+=back
+
+=head1 Selected Bug Fixes
+
+(バグ修正の抜粋)
+
+=over 4
+
+=item *
+
+=begin original
+
+The delimiter C<SYRIAC COLON SKEWED LEFT/RIGHT> pair has been removed
+from the ones recognized by the C<extra_paired_delimiters> feature.
+(See L<perlop/Quote and Quote-like Operators>.)  This is because those
+characters are normally written right-to-left, and this could be
+visually confusing [L<GH #22228|https://github.com/Perl/perl5/issues/22228>].
+The change was actually to forbid any right-to-left delimiters, but this
+pair is the only current instance that meets this criterion.  By policy,
+this change means that the C<extra_paired_delimiters> feature cannot be
+considered to have been stable long enough for its experimental status to
+be removed.
+
+=end original
+
+区切り文字 C<SYRIC C COLON SKEWED LEFT/RIGHT> の組は、
+C<extra_paired_delimiters> 機能で認識される組から削除されました
+(L<perlop/Quote and Quote-like Operators> を参照)。
+これは、これらの文字が通常右から左に書かれているため、視覚的に混乱する
+可能性があるためです[L<GH #22228|https://github.com/Perl/perl5/issues/22228>]。
+この変更は、実際には右から左の区切り文字を禁止するためのものでしたが、
+現在この基準を満たすのはこの組だけです。
+ポリシー上、この変更は、C<extra_paired_delimiters> 機能が実験的な状態を
+終了するのに十分な期間安定していたとは考えられないことを意味します。
+
+=item *
+
+=begin original
+
+C<use 5.36;> or later didn't enable the post parse reporting of L<Name
+"%s::%s" used only once: possible typo|perldiag/"Name "%s::%s" used
+only once: possible typo"> warnings when enabling warnings.
+[L<GH #21271|https://github.com/Perl/perl5/issues/21271>]
+
+=end original
+
+C<use 5.36;> 以降では、警告を有効にしたときに、
+L<Name "%s::%s" used only once: possible typo|perldiag/"Name "%s::%s" used only once: possible typo">
+警告の、パース後の報告が有効になっていませんでした。
+[L<GH #21271|https://github.com/Perl/perl5/issues/21271>]
+
+=item *
+
+=begin original
+
+Fix a crash or assertion when cleaning up a closure that refers to an
+outside C<our> sub.  [L<GH #21067|https://github.com/Perl/perl5/issues/21067>]
+
+=end original
+
+外部の C<our> サブルーチンを参照するクロージャをクリーンアップするときの
+クラッシュやアサーションを修正しました。
+[L<GH #21067|https://github.com/Perl/perl5/issues/21067>]
+
+=item *
+
+=begin original
+
+Fixed a number of issues where C<I32> was used as a string offset or
+size rather than C<SSize_t> or C<STRLEN>/C<size_t> [L<GH #21012|https://github.com/Perl/perl5/issues/21012>]
+
+=end original
+
+C<SSize_t> または C<STRLEN>/C<size_t> ではなく、
+C<I32> が文字列のオフセットまたはサイズとして使われる場合の
+多くの問題が修正されました。
+[L<GH #21012|https://github.com/Perl/perl5/issues/21012>]
+
+=item *
+
+=begin original
+
+C<~$str> when C<$str> was more than 2GB in size would do nothing or
+produce an incomplete result.
+
+=end original
+
+C<$str> のサイズが 2GB を超える場合、C<~$str> は何も実行しなかったり、
+不完全な結果を生成したりしていました。
+
+=item *
+
+=begin original
+
+String repeat, C<$str x $count>, didn't handle C<$str> over 2GB in
+size, throwing an error.  Now such strings are repeated.
+
+=end original
+
+文字列の繰り返し C<$str x $count> は、サイズが 2GB を超える
+C<$str> を処理できず、エラーが投げられていました。
+このような文字列は繰り返されるようになりました。
+
+=item *
+
+=begin original
+
+Complex substitution after the 2GB point in a string could access
+incorrect or invalid offsets in the string.
+
+=end original
+
+文字列内の 2GB よりの後の位置での複雑な置換は、文字列内の不正または
+無効なオフセットにアクセスする可能性がありました。
+
+=item *
+
+=begin original
+
+sv_utf8_decode() would truncate the SVs pos() value.  This wasn't
+visible via utf8::decode().
+
+=end original
+
+sv_utf8_decode() は SV の pos() の値を切り捨てます。
+これは utf8::decode() では見ることができませんでした。
+
+=item *
+
+=begin original
+
+When compiling a constant folded hash key, the length was truncated
+when creating the shared SV.  Since hash keys over 2GB are not
+supported, throw a compilation error instead.
+
+=end original
+
+定数折り畳みハッシュキーをコンパイルするとき、共有 SV の作成時に
+長さが切り捨てられていました。
+2GB を超えるハッシュキーには対応していないため、代わりに
+コンパイルエラーが投げられます。
+
+=item *
+
+=begin original
+
+msgrcv() incorrectly called get magic on the buffer SV and failed to
+call set magic on completion.
+[L<GH #21012|https://github.com/Perl/perl5/issues/21012>]
+
+=end original
+
+msgrcv() がバッファ SV に誤って get magic を呼び出し、完了時に
+set magic を呼び出していませんでした。
+[L<GH #21012|https://github.com/Perl/perl5/issues/21012>]
+
+=item *
+
+=begin original
+
+msgrcv() used the size parameter to resize the buffer before
+validating it. [L<GH #21012|https://github.com/Perl/perl5/issues/21012>]
+
+=end original
+
+msgrcv() は、size 引数を検証する前に、バッファのサイズを変更するために
+これを使っていました。
+[L<GH #21012|https://github.com/Perl/perl5/issues/21012>]
+
+=item *
+
+=begin original
+
+Inheriting from a class that was hierarchically an ancestor of the new
+class, eg. C< class A::B :isa(A) { ... } >, would not attempt to load
+the parent class. [L<GH #21332|https://github.com/Perl/perl5/issues/21332>]
+
+=end original
+
+階層的に新しいクラスの祖先であるクラスから継承する場合、たとえば
+C<class A::B:isa(A){.}> は親クラスをロードしようとしませんでした。
+[L<GH #21332|https://github.com/Perl/perl5/issues/21332>]
+
+=item *
+
+=begin original
+
+Declared references can now be used with C<state> variables.
+[L<GH #21351|https://github.com/Perl/perl5/issues/21351>]
+
+=end original
+
+宣言されたリファレンスを C<state> 変数で使えるようになりました。
+[L<GH #21351|https://github.com/Perl/perl5/issues/21351>]
+
+=item *
+
+=begin original
+
+Trailing elements in an C<unshift>ed and resized array will now always be
+initialized. [L<GH #21265|https://github.com/Perl/perl5/issues/21265>]
+
+=end original
+
+C<unshift> されてサイズ変更された配列の末尾要素は、
+常に初期化されるようになりました。
+[L<GH #21265|https://github.com/Perl/perl5/issues/21265>]
+
+=item *
+
+=begin original
+
+Make C<use 5.036> respect the -X flag
+
+=end original
+
+C<use 5.036> が -X フラグを考慮するようになりました
+
+=begin original
+
+perl's -X flag disables all warnings globally, but «use 5.036» didn't
+respect that until now. [L<GH #21431|https://github.com/Perl/perl5/issues/21431>]
+
+=end original
+
+perl の -X フラグはすべての警告をグローバルに無効にしますが、
+"use 5.036" は今までそれを考慮していませんでした。
+[L<GH #21431|https://github.com/Perl/perl5/issues/21431>]
+
+=item *
+
+=begin original
+
+Fixed an OP leak when an error was produced for initializer for a class
+field. [L<GH #20812|https://github.com/Perl/perl5/issues/20812>]
+
+=end original
+
+クラスフィールドの初期化処理でエラーが発生した場合の
+OP リークが修正されました。
+[L<GH #20812|https://github.com/Perl/perl5/issues/20812>]
+
+=item *
+
+=begin original
+
+Fixed a leak of the return value when smartmatching against a code reference.
+
+=end original
+
+コードリファレンスに対してスマートマッチングする場合の
+帰り値のリークが修正されました。
+
+=item *
+
+=begin original
+
+Fixed a slowdown in repeated substitution replacements using special
+variables, such as C<s/....x$1/g>. It actually makes all string
+concatenations involving such "magic" variables less slow, but the
+slowdown was more noticeable on repeated substitutions due to extra memory
+usage that was only freed after the last iteration. The slowdown started
+in perl 5.28.0 - which generally sped up string concatenation but slowed
+down when using special variables.
+[L<GH #21360|https://github.com/Perl/perl5/issues/21360>]
+
+=end original
+
+C<s/....x$1/g> のような特殊変数を使用した置換の繰り返しの速度低下が
+修正されました。
+実際には、このような「マジック」変数を含むすべての文字列連結の
+速度低下が現象しますが、最後の反復後のみ解放される余分なメモリ使用量のために、
+置換を繰り返すと速度低下がより顕著になりました。
+速度低下は perl 5.28.0 で始まりました -
+これは一般的に文字列連結を高速化しましたが、特殊変数を使うと
+速度が低下しました。
+[L<GH #21360|https://github.com/Perl/perl5/issues/21360>]
+
+=item *
+
+=begin original
+
+Lexical names from the enclosing scope in a lexical sub or closure
+weren't visible to code executed by calling C<eval EXPR;> from the
+C<DB> package.  This was introduced in 5.18 in an attempt to prevent
+subs from retaining a reference to their outer scope, but this broke
+the special behaviour of C<eval EXPR;> in package DB.
+
+=end original
+
+C<DB> パッケージから C<eval EXPR;> を呼び出すことによって
+実行されたコードでは、レキシカルサブルーチンまたはクロージャ内の
+包含スコープからのレキシカル名は表示されませんでした。
+これは、サブルーチンが外部スコープへの参照を保持しないようにするために
+5.18 に導入されましたが、これにより DB パッケージ内の C<eval EXPR;> の
+特殊な動作が壊れました。
+
+=begin original
+
+This incidentally fixed a TODO test for C<B::Deparse>.
+[L<GH #19370|https://github.com/Perl/perl5/pull/19370>]
+
+=end original
+
+これにより、C<B::Deparse> の TODO テストが偶然修正されました。
+[L<GH #19370|https://github.com/Perl/perl5/pull/19370>]
+
+=item *
+
+=begin original
+
+Optionally support an argument stack over 2**32 entries on 64-bit
+platforms.  This requires 32GB of memory just for the argument stack
+pointers itself, so you will require a significantly more memory to
+take advantage of this.
+
+=end original
+
+オプションで、64ビットプラットフォームで 2**32 エントリを超える
+引数スタックに対応します。
+これには、引数スタックポインタ自体のためだけに 32 GB のメモリが
+必要になるため、これを利用するには大幅に多くのメモリが必要になります。
+
+=begin original
+
+To enable this add C<-Accflags=-DPERL_STACK_OFFSET_SSIZET> or
+equivalent to the C<Configure> command-line.
+
+=end original
+
+これを有効にするには、C<-Accflags=-DPERL_STACK_OFFSET_SSIZET> または
+同等のものを C<Configure> コマンドラインに追加します。
+
+[L<GH #20917|https://github.com/Perl/perl5/issues/20917>]
+[L<GH #21523|https://github.com/Perl/perl5/issues/21523>]
+
+=item *
+
+=begin original
+
+Fixed various problems with join() where modifications to the
+separator could be handled inconsistently, or could access released
+memory.  Changes to the separator from magic or overloading for values
+in the C<LIST> no longer have an effect on the resulting joined
+string.
+[L<GH #21458|https://github.com/Perl/perl5/issues/21458>]
+
+=end original
+
+join() で、区切り文字の変更が一貫性なく処理されたり、解放されたメモリに
+アクセスしたりする可能性があるさまざまな問題が修正されました。
+マジックまたは C<LIST> 内の値のオーバーロードによる区切り文字の変更は、
+結果の結合された文字列に影響しなくなりました。
+[L<GH #21458|https://github.com/Perl/perl5/issues/21458>]
+
+=item *
+
+=begin original
+
+Don't clear the integer flag C<IOK> from lines in the C<<
+@{"_<$sourcefile"} >> array when a C<dbstate> op is removed for that
+line.  This was broken when fixing
+[L<GH #19198|https://github.com/Perl/perl5/issues/19198>].
+[L<GH #21564|https://github.com/Perl/perl5/issues/21564>]
+
+=end original
+
+C<< @{"_<$sourcefile"} >> 配列の行で C<dbstate> op が削除されたときに、
+その行の整数フラグ C<IOK> をクリアしません。
+これは [L<GH #19198|https://github.com/Perl/perl5/issues/19198>] を
+修正したときに壊れました。
+[L<GH #21564|https://github.com/Perl/perl5/issues/21564>]
+
+=item *
+
+=begin original
+
+Many bug fixes have been made for using locales under threads and in
+embedded perls.  And workarounds for libc bugs have been added.  As a
+result thread-safe locale handling is now the default under OpenBSD, and
+MingW when compiled with UCRT.
+
+=end original
+
+スレッドの下や組み込みの perl でロケールを使うための多くのバグ修正が
+行われました。
+libc バグの回避策も追加されました。
+その結果、OpenBSD および UCRT でコンパイルした MingW では、
+スレッドセーフなロケール処理のデフォルトになりました。
+
+=begin original
+
+However, testing has shown that Darwin's implementation of thread-safe
+locale handling has bugs.  So now Perl doesn't attempt to use the
+thread-safe operations when compiled on Darwin.
+
+=end original
+
+しかし、テストの結果、Darwin のスレッドセーフなロケール処理の実装には
+バグがあることがわかりました。
+そのため、Perl は Darwin でコンパイルされたときにスレッドセーフな操作を
+使おうとしなくなりました。
+
+=begin original
+
+As before, you can check to see if your program is running with
+thread-safe locales by checking if the value of C<${^SAFE_LOCALES}> is
+1.
+
+=end original
+
+以前と同様、C<${^SAFE_LOCALES}> の値が 1 かどうかをチェックすることで、
+プログラムがスレッドセーフなロケールで実行されているかどうかを確認できます。
+
+=item *
+
+=begin original
+
+Various bugs have been fixed when perl is configured with
+C<-Accflags=-DNO_LOCALE_NUMERIC> or any other locale category (or
+categories).
+
+=end original
+
+perl が C<-Accflags=-DNO_LOCALE_NUMERIC> またはその他のロケールカテゴリで
+設定されている場合の様々なバグが修正されました。
+
+=item *
+
+=begin original
+
+Not all locale categories need be set to the same locale.  Perl now
+works around bugs in the libc implementations of locale handling on some
+platforms that previously could result in mojibake.
+
+=end original
+
+すべてのロケールカテゴリを同じロケールに設定する必要はありません。
+Perl は、以前は文字化けになる可能性があった、いくつかのプラットフォームでの
+ロケール処理の libc 実装のバグを回避できるようになりました。
+
+=item *
+
+=begin original
+
+C<LC_ALL> is represented in one of two ways when not all locale
+categories are set to the same locale.  On some platforms, such as Linux
+and Windows, the representation is of the form of a series of
+C<'category=locale-name'> pairs.  On other platforms, such as *BSD, the
+representation is positional like S<C<I<name1> / I<name2> / ... >>.
+I<name1> is always for a particular category as defined by the platform,
+as are the other names.  The sequence that separates the names
+(the S<C< / >> above) also varies by platform.  Previously, perl had
+problems with platforms that used the positional notation.  This is now
+fixed.
+
+=end original
+
+C<LC_ALL> は、すべてのロケールカテゴリが同じロケールに設定されていない場合、
+二つの方法のいずれかで表現されます。
+Linux や Windows などの一部のプラットフォームでは、表現は一連の
+C<'category=locale-name'> の組の形式になります。
+*BSD などの他のプラットフォームでは、表現は
+S<C<I<name1> / I<name2> / ... >> のような位置になります。
+I<name1> は、他の名前と同様に、プラットフォームによって定義された特定の
+カテゴリを表します。
+名前を区切る順序(前述の S<C< / >>)もプラットフォームによって異なります。
+以前は、位置表記を使うプラットフォームで perl に問題がありました。
+これは修正されました。
+
+=item *
+
+=begin original
+
+A bug has been fixed in the regexp engine with an optimisation that applies
+to the C<+> quantifier where it was followed by a C<(*SKIP)> pattern.
+
+=end original
+
+C<(*SKIP)> パターンが後に続く C<+> 量指定子に適用される最適化に関する
+正規表現エンジンのバグが修正されました。
+
+[L<GH #21534|https://github.com/Perl/perl5/issues/21534>]
+
+=item *
+
+=begin original
+
+The tmps (mortal) stack now grows exponentially.  Previously it grew
+linearly, so if it was growing incrementally, such as through many
+calls to sv_2mortal(), on a system where realloc() is O(size), the
+performance would be O(n*n).  With exponential grows this changes to
+amortized O(n).  [L<GH #21654|https://github.com/Perl/perl5/issues/21654>]
+
+=end original
+
+tmps(揮発性)スタックは指数関数的に増加するようになりました。
+以前は直線的に増加していたので、realloc() が O(サイズ) のシステムで
+sv_2mortal() を何度も呼び出すなどして徐々に増加した場合、
+パフォーマンスは O(n*n) になります。
+指数関数的に増加すると、これは償却された O(n) に変わります。
+[L<GH #21654|https://github.com/Perl/perl5/issues/21654>]
+
+=item *
+
+=begin original
+
+Lexical subs now have a new stub in the pad for each recursive call
+into the containing function.  This fixes two problems:
+
+=end original
+
+レキシカルサブルーチンは、包含関数への各再帰呼び出しのパッドに
+新しいスタブを持つようになりました。
+これは次の二つの問題を解決します:
+
+=over
+
+=item *
+
+=begin original
+
+If the lexical sub called the containing function, a "Can't undef
+active subroutine" error would be thrown.  For example:
+
+=end original
+
+レキシカルサブルーチンが包含関数を呼び出すと、
+"Can't undef active subroutine" というエラーが投げられます。
+例えば:
+
+    use v5.36.0;
+    sub outer($oc) {
+        my sub inner ($c) {
+             outer($c-1) if $c; # Can't undef active subroutine
+        }
+        inner($oc);
+    }
+    outer(2);
+
+[L<GH #18606|https://github.com/Perl/perl5/issues/18606>]
+
+=item *
+
+=begin original
+
+If the lexical sub was called from a recursive call into the
+containing function, this would overwrite the bindings to the closed
+over variables in the lexical sub, so calls into the lexical sub from
+the outer recursive call would have access to the variables from the
+inner recursive call:
+
+=end original
+
+レキシカルサブルーチンが再帰呼び出しから包含関数に呼び出された場合、
+これはレキシカルサブルーチン内のクローズオーバー変数への束縛を
+上書きするため、外部再帰呼び出しからレキシカルサブルーチンへの
+呼び出しは内部変数からの変数にアクセスできるようになっていました:
+
+    use v5.36.0;
+    sub outer ($x) {
+        my sub inner ($label) {
+            say "$label $x";
+        }
+        inner("first");
+        outer("inner") if $x eq "outer";
+        # this call to inner() sees the wrong $x
+        inner("second");
+    }
+    outer("outer");
+
+[L<GH #21987|https://github.com/Perl/perl5/issues/21987>]
+
+=back
+
+=item *
+
+=begin original
+
+prepare_export_lexical() was separately saving C<PL_comppad> and
+C<PL_curpad>, this could result in C<PL_curpad> being restored to a no
+longer valid value, resulting in a panic when importing lexicals in
+some cases.  [L<GH #21981|https://github.com/Perl/perl5/issues/21981>]
+
+=end original
+
+prepare_export_lexical() は C<PL_comppad> と C<PL_curpad> を別々に
+保存していました;
+これにより、C<PL_curpad> がもはや有効でない値に復元され、
+場合によってはレキシカル変数をインポートするときにパニックが
+起きる可能性がありました。
+[L<GH #21981|https://github.com/Perl/perl5/issues/21981>]
+
+=item *
+
+=begin original
+
+A string eval() operation in the scope of a C<use VERSION> declaration would
+sometimes emit spurious "Downgrading a use VERSION declaration" warnings due
+to an inconsistency in the way the version number was stored.  This is now
+fixed.
+[L<GH #22121|https://github.com/Perl/perl5/issues/22121>]
+
+=end original
+
+C<use VERSION> 宣言のスコープ内で文字列 eval() 操作を行うと、
+バージョン番号の格納方法の矛盾のため、
+"Downgrading a use VERSION declaration" という
+誤った警告が表示されることがありました。
+これは修正されました。
+[L<GH #22121|https://github.com/Perl/perl5/issues/22121>]
+
+=back
+
+=head1 Known Problems
+
+(既知の問題)
+
+=over 4
+
+=item * perlivp is missing streamzip on Windows
+
+(perlivp は Windows で streamzip がありません)
+
+=begin original
+
+The C<streamzip> utility does not get installed on Windows but should
+get installed.
+
+=end original
+
+C<streamzip> ユーティリティは Windows にはインストールされませんが、
+インストールされるする必要があります。
+
+=back
+
+=head1 Errata From Previous Releases
+
+(以前のリリースの訂正)
+
+=over 4
+
+=item *
+
+=begin original
+
+L<perl5300delta> has been updated to include the removal of the C<arybase> module that happened at
+the same time as the removal of C<$[>.
+
+=end original
+
+L<perl5300delta> は、C<$[> の削除と同時に行われた C<arybase> モジュールの
+削除を含むように更新されました。
+
+=back
+
+=head1 Acknowledgements
+
+(謝辞)
+
+=begin original
+
+Perl 5.40.0 represents approximately 11 months of development since Perl
+5.38.0 and contains approximately 160,000 lines of changes across 1,500
+files from 75 authors.
+
+=end original
+
+Perl 5.40.0 は、Perl 5.38.0 以降、75 人の作者によって、
+1,500 のファイルに約 160,000 行の変更を加えて、
+約 11 ヶ月開発されてきました。
+
+=begin original
+
+Excluding auto-generated files, documentation and release tools, there were
+approximately 110,000 lines of changes to 1,200 .pm, .t, .c and .h files.
+
+=end original
+
+自動生成ファイル、文書、リリースツールを除くと、1,200 の .pm, .t, .c,
+.h ファイルに約 110,000 行の変更を加えました。
+
+=begin original
+
+Perl continues to flourish into its fourth decade thanks to a vibrant
+community of users and developers. The following people are known to have
+contributed the improvements that became Perl 5.40.0:
+
+=end original
+
+Perl は、活気のあるユーザーと開発者のコミュニティのおかげで 30 年を超えて
+繁栄しています。
+以下の人々が、Perl 5.40.0 になるための改良に貢献したことが分かっています:
+
+Abe Timmerman, Alexander Kanavin, Amory Meltzer, Aristotle Pagaltzis, Arne
+Johannessen, Beckett Normington, Bernard Quatermass, Bernd, Bruno Meneguele,
+Chad Granum, Chris 'BinGOs' Williams, Christoph Lamprecht, Craig A. Berry,
+Dagfinn Ilmari Mannsåker, Dan Book, Dan Church, Daniel Böhmer, Dan
+Jacobson, Dan Kogai, David Golden, David Mitchell, E. Choroba, Elvin
+Aslanov, Erik Huelsmann, Eugen Konkov, Gianni Ceccarelli, Graham Knop, Greg
+Kennedy, guoguangwu, Hauke D, H.Merijn Brand, Hugo van der Sanden, iabyn,
+Jake Hamby, Jakub Wilk, James E Keenan, James Raspass, Joe McMahon, Johan
+Vromans, John Karr, Karen Etheridge, Karl Williamson, Leon Timmermans, Lukas
+Mai, Marco Fontani, Marek Rouchal, Martijn Lievaart, Mathias Kende, Matthew
+Horsfall, Max Maischein, Nicolas Mendoza, Nicolas R, OpossumPetya, Paul
+Evans, Paul Marquess, Peter John Acklam, Philippe Bruhat (BooK), Raul E
+Rangel, Renee Baecker, Ricardo Signes, Richard Leach, Scott Baker, Sevan
+Janiyan, Sisyphus, Steve Hay, TAKAI Kousuke, Todd Rinaldo, Tomasz Konojacki,
+Tom Hughes, Tony Cook, William Lyu, x-yuri, Yves Orton, Zakariyya Mughal,
+Дилян Палаузов.
+
+=begin original
+
+The list above is almost certainly incomplete as it is automatically
+generated from version control history. In particular, it does not include
+the names of the (very much appreciated) contributors who reported issues to
+the Perl bug tracker.
+
+=end original
+
+これはバージョンコントロール履歴から自動的に生成しているので、ほぼ確実に
+不完全です。
+特に、Perl バグトラッカーに問題を報告をしてくれた (とてもありがたい)貢献者の
+名前を含んでいません。
+
+=begin original
+
+Many of the changes included in this version originated in the CPAN modules
+included in Perl's core. We're grateful to the entire CPAN community for
+helping Perl to flourish.
+
+=end original
+
+このバージョンに含まれている変更の多くは、Perl コアに含まれている CPAN
+モジュール由来のものです。
+私たちは Perl の発展を助けている CPAN コミュニティ全体に感謝します。
+
+=begin original
+
+For a more complete list of all of Perl's historical contributors, please
+see the F<AUTHORS> file in the Perl source distribution.
+
+=end original
+
+全ての Perl の歴史的な貢献者のより完全な一覧については、どうか Perl ソース
+配布に含まれている F<AUTHORS> を参照してください。
+
+=head1 Reporting Bugs
+
+(バグ報告)
+
+=begin original
+
+If you find what you think is a bug, you might check the perl bug database
+at L<https://github.com/Perl/perl5/issues>.  There may also be information at
+L<https://www.perl.org/>, the Perl Home Page.
+
+=end original
+
+もしバグと思われるものを見つけたら、
+L<https://github.com/Perl/perl5/issues> にある perl バグデータベースを
+確認してください。
+Perl ホームページ、L<https://www.perl.org/> にも情報があります。
+
+=begin original
+
+If you believe you have an unreported bug, please open an issue at
+L<https://github.com/Perl/perl5/issues>.  Be sure to trim your bug down to a
+tiny but sufficient test case.
+
+=end original
+
+もしまだ報告されていないバグだと確信したら、
+L<https://github.com/Perl/perl5/issues> にイシューを登録してください。
+バグの再現スクリプトを十分小さく、しかし有効なコードに切りつめることを
+意識してください。
+
+=begin original
+
+If the bug you are reporting has security implications which make it
+inappropriate to send to a public issue tracker, then see
+L<perlsec/SECURITY VULNERABILITY CONTACT INFORMATION>
+for details of how to report the issue.
+
+=end original
+
+報告しようとしているバグがセキュリティに関するもので、公開されている
+イシュートラッカーに送るのが不適切なものなら、バグの報告方法の詳細について
+L<perlsec/SECURITY VULNERABILITY CONTACT INFORMATION> を参照してください。
+
+=head1 Give Thanks
+
+(感謝を伝える)
+
+=begin original
+
+If you wish to thank the Perl 5 Porters for the work we had done in Perl 5,
+you can do so by running the C<perlthanks> program:
+
+=end original
+
+もし Perl 5 でなされた作業について Perl 5 Porters に感謝したいと考えたなら、
+C<perlthanks> プログラムを実行することでそうできます:
+
+    perlthanks
+
+=begin original
+
+This will send an email to the Perl 5 Porters list with your show of thanks.
+
+=end original
+
+これは Perl 5 Porters メーリングリストにあなたの感謝の言葉をメールします。
+
+=head1 SEE ALSO
+
+=begin original
+
+The F<Changes> file for an explanation of how to view exhaustive details on
+what changed.
+
+=end original
+
+変更点の完全な詳細を見る方法については F<Changes> ファイル。
+
+=begin original
+
+The F<INSTALL> file for how to build Perl.
+
+=end original
+
+Perl のビルド方法については F<INSTALL> ファイル。
+
+=begin original
+
+The F<README> file for general stuff.
+
+=end original
+
+一般的なことについては F<README> ファイル。
+
+=begin original
+
+The F<Artistic> and F<Copying> files for copyright information.
+
+=end original
+
+著作権情報については F<Artistic> 及び F<Copying> ファイル。
+
+=cut
+
+=begin meta
+
+Translate: SHIRAKATA Kentaro <argrath@ub32.org>
+Status: completed
+
+=end meta
+


### PR DESCRIPTION
Perl 5.40.0 がリリース間近なのでperl5400deltaを翻訳する。

RC1が出たのでまずはこれをベースに翻訳し、正式版が出たら変更点を調整してリリースする。