### PR TITLE
Mouse::Manual::Construction の修正

### DIFF
--- a/docs/modules/Moose-0.92/Moose/Manual/Construction.pod
+++ b/docs/modules/Moose-0.92/Moose/Manual/Construction.pod
@@ -30,7 +30,7 @@ C<BUILDARGS>は、ハッシュ（リファレンス）以外の呼び出し方�
 
 この場合、C<BUILDARGS>メソッドがないと、Mooseは（ハッシュまたはハッシュリファレンスを期待しているので）エラーを発生させますが、C<BUILDARGS>メソッドを使うとこの呼び出し方に対応できます。
 
-  around BUILDARGS {
+  around BUILDARGS => sub {
       my $orig = shift;
       my $class = shift;
 
@@ -40,7 +40,7 @@ C<BUILDARGS>は、ハッシュ（リファレンス）以外の呼び出し方�
       else {
           return $class->$orig(@_);
       }
-  }
+  };
 
 C<$class->$orig>を呼んでいることに注意してください。これは親クラスのメソッドを呼び出すことによりL<Moose::Object>にデフォルトで用意されているC<BUILDARGS>を呼ぶものです。このメソッドを使うとハッシュリファレンスとただのハッシュを区別してくれます。
 


### PR DESCRIPTION
around の使い方を間違えているので修正


https://metacpan.org/dist/Moose/view/lib/Moose/Manual/Construction.pod#BUILDARGS